### PR TITLE
add "encrypted" field explanation (4127).

### DIFF
--- a/documentation/en/source/pages/templates-spec/stack-installation-rootuser.rst
+++ b/documentation/en/source/pages/templates-spec/stack-installation-rootuser.rst
@@ -17,10 +17,11 @@ The definition of a rootUser section is:
 
 The valid keys to use within a rootUser are:
 
-* disablePasswordLogin (optional): a boolean to determine whether to disable the ability for the root user to login into a running instance using the root password.
-* password (optional): a string providing the root user password. A blank password "" is valid.
-* setPassword (mandatory): a boolean to determine whether to preset a password during the build or prompt the user to add a password during first boot of the instance.
-* sshKeys (optional): an array of objects providing one or more public ssh keys for the root user. For more information, refer to the :ref:`stack-installation-sshkeys` sub-section.
+* ``disablePasswordLogin`` (optional): a boolean to determine whether to disable the ability for the root user to login into a running instance using the root password.
+* ``password`` (optional): a string providing the root user password. A blank password "" is valid.
+* ``encrypted`` (optional): a boolean to determine whether password is encrypted or not. The default is false.
+* ``setPassword`` (mandatory): a boolean to determine whether to preset a password during the build or prompt the user to add a password during first boot of the instance.
+* ``sshKeys`` (optional): an array of objects providing one or more public ssh keys for the root user. For more information, refer to the :ref:`stack-installation-sshkeys` sub-section.
 
 Sub-sections
 ------------

--- a/documentation/en/source/pages/templates-spec/stack-installation-users.rst
+++ b/documentation/en/source/pages/templates-spec/stack-installation-users.rst
@@ -21,6 +21,7 @@ The valid keys to use within a user are:
 * ``homeDir`` (mandatory): a string providing the home directory of the user. Recommended default: ``/home/username`` where username is the same value as ``name``
 * ``name`` (mandatory): a string providing the name of the user. The name cannot contain any spaces.
 * ``password`` (optional): a string providing the user password.
+* ``encrypted`` (optional): a boolean to determine whether password is encrypted or not. The default is false.
 * ``primaryGroup`` (optional): a string providing the user’s primary group. If no primary group is given, then the primary group is the same as name.
 * ``shell`` (mandatory): a string providing the default shell environment for the user. Recommended default is ``/bin/bash``.
 * ``secondaryGroups`` (optional): a string providing one or more group names separated by a comma (,).


### PR DESCRIPTION

 - add expalantion of "encrypted" field to rootUser and users page.
   http://hammr.readthedocs.io/en/latest/pages/templates-spec/stack-installation-rootuser.html
   http://hammr.readthedocs.io/en/latest/pages/templates-spec/stack-installation-users.html
 - surround field name in stack-installation-rootuser.rst using `` `` like other documents so that it looks fine.
