### PR TITLE
Add time and timezone to updateTo date

### DIFF
--- a/documentation/en/source/pages/templates-spec/stack-os.rst
+++ b/documentation/en/source/pages/templates-spec/stack-os.rst
@@ -23,7 +23,7 @@ The valid keys to use within the os object are:
 * ``name`` (mandatory): a string providing the name of the operating system to use
 * ``pkgs`` (optional): an array providing any extra packages to install (see pkgs key sub-section for more information)
 * ``profile`` (mandatory): a string providing which operating system profile to use
-* ``updateTo`` (optional): a string providing the date where package versions should be calculated (determines which package versions to use to * calculate the package dependency tree)
+* ``updateTo`` (optional): a string providing the date and time where package versions should be calculated (determines which package versions to use to * calculate the package dependency tree)
 * ``version`` (mandatory): a string providing the version of the operating system to use
 
 Sub-Sections
@@ -58,10 +58,24 @@ The following example describes using CentOS 6.4 64 bit operating system for the
 
 The name, version, arch and profile values for an operating system can be found by using the command ``os list``. This lists all the operating systems you have access to.
 
-Specifying a Build Date
+Specifying a Build Date/Time
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-By using the ``updateTo`` key will specify the date to calculate the version and release of all the packages to use in the template during the build phase of a machine image. This allows you to roll-back or update the operating system packages used. If no date is provided, then the date the template is created is used. The example below sets the date to 14 May 2014.
+By using the ``updateTo`` key will specify the date and time to calculate the version and release of all the packages to use in the template during the build phase of a machine image. This allows you to roll-back or update the operating system packages used. If no date is provided, then the date the template is created is used. The example below sets the date to 14 May 2014 00:00 UTC. Note that timezone must respect `General Time Zone <http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html#timezone>`_ format.
+
+.. code-block:: json
+
+	{
+	  "os": {
+	    "name": "CentOS",
+	    "version": "6.4",
+	    "arch": "x86_64",
+	    "profile": "Minimal"
+	    "updateTo": "2014-05-14 00:00 UTC"
+	  }
+	}
+	
+You can still use a date without time information, in such case time will be interpreted by server as midnight in server's own timezone (UTC by default). 
 
 .. code-block:: json
 


### PR DESCRIPTION
#73 An issue in UForge 3.6 lead to change date format in order to handle time and timezone information. Documentation has to be fixed in consequence.