### PR TITLE
Fix #90 : An integration test failed due to the error "The value of a script boot order is not an integer"

### DIFF
--- a/tests/integration/data/templateFull.json
+++ b/tests/integration/data/templateFull.json
@@ -72,7 +72,8 @@
       "name": "configure-mysql.sh",
       "source": "data/bootsrcripts/cleanup_tmp.sh",
       "type": "bootscript",
-      "frequency": "firstboot"
+      "frequency": "firstboot",
+      "order" : "1"
     }
     ],
     "os" : {


### PR DESCRIPTION
 - now "order" is required for the boot script configuration.
 - added it to templateFull.json.
