### PR TITLE
(fix) Template.do_validate failed with an error "object has no attribute 'validate_json_file'" #92

### DIFF
--- a/src/hammr/commands/template/template.py
+++ b/src/hammr/commands/template/template.py
@@ -195,7 +195,7 @@ class Template(Cmd, CoreGlobal):
             file = generics_utils.get_file(doArgs.file)
             if file is None:
                 return 2
-            template=generics_utils.validate_json_file(file)
+            template=validate_json_file(file)
             if template is None:
                 return 2
             return 0


### PR DESCRIPTION

 - The validate_json_file method is moved from generics_utils to hammr_utils.
 - But the do_validate still calls "generics_utils.validate_json_file".
 - Fixed to use hammr_utils.validate_json_file.