### PR TITLE
(fix) Long format name is required for image type. #94

### DIFF
--- a/src/hammr/commands/template/template.py
+++ b/src/hammr/commands/template/template.py
@@ -381,7 +381,7 @@ class Template(Cmd, CoreGlobal):
                         format_type = builder["type"]
                         targetFormat = generate_utils.get_target_format_object(self.api, self.login, format_type)
                         if targetFormat is None:
-                            printer.out("Builder type unknown: "+format_type, printer.ERROR)
+                            printer.out("Builder type unknown: "+format_type+", Please check access rights to the format.", printer.ERROR)
                             return 2
 
                         myimage = image()
@@ -400,7 +400,7 @@ class Template(Cmd, CoreGlobal):
                         if func:
                             myimage,myinstallProfile = func(myimage, builder, myinstallProfile, self.api, self.login)
                         else:
-                            printer.out("Builder type unknown: "+format_type, printer.ERROR)
+                            printer.out("Builder type unknown: "+format_type+" is not supported.", printer.ERROR)
                             return 2
 
 

--- a/src/hammr/utils/generate_utils.py
+++ b/src/hammr/utils/generate_utils.py
@@ -380,6 +380,6 @@ def get_target_format_object(api, login, targetFormatName):
         return None
     else:
         for item in targetFormatsUser.targetFormats.targetFormat:
-            if (item.name == targetFormatName):
+            if (item.format.name == targetFormatName):
                 return item
     return None

--- a/tests/integration/data/template.json
+++ b/tests/integration/data/template.json
@@ -16,7 +16,7 @@
  },
  "builders" : [
  {
-  "type" : "KVM",
+  "type" : "kvm",
   "hardwareSettings" : {
   "memory" : 1024
   },
@@ -25,7 +25,7 @@
   }
  },
  {
-  "type" : "Amazon AWS",
+  "type" : "aws",
   "hardwareSettings" : {
   "memory" : 1024
   },

--- a/tests/integration/data/templateFull.json
+++ b/tests/integration/data/templateFull.json
@@ -93,7 +93,7 @@
   },
   "builders" : [
    {
-        "type" : "KVM",
+        "type" : "kvm",
 	"hardwareSettings": {
                 "memory": 1024
             }


### PR DESCRIPTION
 - The format type in builder should be short format name like "azure" or
   "aws". But now long name like "Microsoft Azure" or "Amazon AWS" is
   required.
 - Fixed to use short format type name.
 - Modified error message so that user can recognize if it is not
   supported by uforge (or do not have rights) or not suppoted by hammr.