### PR TITLE
FIX #99 Error "broken pipe" when execute python clean command

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -39,7 +39,8 @@ class CleanCommand(Command):
     def finalize_options(self):
         pass
     def run(self):
-        os.system('rm -vrf ./build ./dist ./*.pyc ./*.egg-info | find -iname "*.pyc" -exec rm {} +')
+        os.system('rm -vrf ./build ./dist ./*.pyc ./*.egg-info')
+        os.system('find -iname "*.pyc" -exec rm {} +')
 
 setup (  
 


### PR DESCRIPTION
Separated the rm command in two lines
