### PR TITLE
RFE: Amazon AWS format support. #96

### DIFF
--- a/documentation/en/source/pages/templates-spec/builders/builders-aws.rst
+++ b/documentation/en/source/pages/templates-spec/builders/builders-aws.rst
@@ -35,11 +35,9 @@ Building a Machine Image
 For building an image, the valid keys are:
 
 * ``type`` (mandatory): a string providing the machine image type to build. Default builder type for Amazon: ``Amazon AWS``. To get the available builder type, please refer to :ref:`command-line-format`
-* ``account`` (mandatory): an object providing the AWS cloud account information required to publish the built machine image.
 * ``disableRootLogin`` (optional): a boolean flag to determine if root login access should be disabled for any instance provisioned from the machine image.
 * ``installation`` (optional): an object providing low-level installation or first boot options. These override any installation options in the :ref:`template-stack` section. The following valid keys for installation are:
-	* ``diskSize`` (mandatory): an integer providing the disk size of the machine image to create. Note, this overrides any disk size information in the stack. If the machine image is to be stored in Amazon S3, the maximum disk size is 10GB, otherwise if this is an EBS-backed machine image the maximum disk size is 1TB.
-* ``ebs`` (optional): a boolean flag to determine if the machine image should be EBS-backed.
+	* ``diskSize`` (mandatory): an integer providing the disk size of the machine image to create. Note, this overrides any disk size information in the stack. As EBS-backed machine image is created, the maximum disk size is 1TB.
 
 Publishing a Machine Image
 --------------------------

--- a/src/hammr/utils/generate_utils.py
+++ b/src/hammr/utils/generate_utils.py
@@ -169,37 +169,12 @@ def generate_azure(image, builder, installProfile, api, login):
 
 
 def generate_aws(image, builder, installProfile, api, login):
-    if "ebs" in builder and builder["ebs"] == "true":
-        image.ebs = True
-        if "diskSize" in builder["installation"]:
-            image.ebsVolumeSize = builder["installation"]["diskSize"]
-        else:
-            printer.out("No disksize set for ebs volume in builder [aws]", printer.ERROR)
-            return None, None
+    image.ebs = True
+    if "diskSize" in builder["installation"]:
+        image.ebsVolumeSize = builder["installation"]["diskSize"]
     else:
-        image.ebs = False
-
-    if "account" in builder and builder["account"] is not None:
-        if not "name" in builder["account"]:
-            printer.out("Account name not found in builder", printer.ERROR)
-            return None, None
-
-        accounts = api.Users(login).Accounts.Getall().credAccounts.credAccount
-        if accounts is None or len(accounts) == 0:
-            printer.out("No accounts available", printer.ERROR)
-            return None, None
-
-        for account in accounts:
-            if account.name == builder["account"]["name"]:
-                image.credAccount = account
-                break
-        if image.credAccount is None:
-            printer.out("Account not found: "+builder["account"]["name"], printer.ERROR)
-            return None, None
-    else:
-        if not image.ebs:
-            printer.out("Account not found in builder", printer.ERROR)
-            return None, None
+        printer.out("No disksize set for ebs volume in builder [aws]", printer.ERROR)
+        return None, None
 
     if "disableRootLogin" in builder:
         myrootUser = osUser()

--- a/src/hammr/utils/generate_utils.py
+++ b/src/hammr/utils/generate_utils.py
@@ -168,23 +168,39 @@ def generate_azure(image, builder, installProfile, api, login):
     return image, installProfile
 
 
-def generate_ami(image, builder, installProfile, api, login):
-    if not "account" in builder:
-        printer.out("Account not found in builder", printer.ERROR)
-        return None, None, None
-    if not "name" in builder["account"]:
-        printer.out("Account anme not found in builder", printer.ERROR)
-        return None, None, None
+def generate_aws(image, builder, installProfile, api, login):
+    if "ebs" in builder and builder["ebs"] == "true":
+        image.ebs = True
+        if "diskSize" in builder["installation"]:
+            image.ebsVolumeSize = builder["installation"]["diskSize"]
+        else:
+            printer.out("No disksize set for ebs volume in builder [aws]", printer.ERROR)
+            return None, None
+    else:
+        image.ebs = False
 
-    accounts = api.Users(login).Accounts.Getall()
-    if accounts is None or not hasattr(accounts, 'get_credAccount'):
-        printer.out("No accounts available", printer.ERROR)
-        return None, None, None
+    if "account" in builder and builder["account"] is not None:
+        if not "name" in builder["account"]:
+            printer.out("Account name not found in builder", printer.ERROR)
+            return None, None
 
-    for account in accounts.get_credAccount():
-        if account.name == builder["account"]["name"]:
-            image.credAccount = account
-            break
+        accounts = api.Users(login).Accounts.Getall().credAccounts.credAccount
+        if accounts is None or len(accounts) == 0:
+            printer.out("No accounts available", printer.ERROR)
+            return None, None
+
+        for account in accounts:
+            if account.name == builder["account"]["name"]:
+                image.credAccount = account
+                break
+        if image.credAccount is None:
+            printer.out("Account not found: "+builder["account"]["name"], printer.ERROR)
+            return None, None
+    else:
+        if not image.ebs:
+            printer.out("Account not found in builder", printer.ERROR)
+            return None, None
+
     if "disableRootLogin" in builder:
         myrootUser = osUser()
         if builder["disableRootLogin"] == "true":
@@ -192,20 +208,10 @@ def generate_ami(image, builder, installProfile, api, login):
         elif builder["disableRootLogin"] == "false":
             val = False
         else:
-            printer.out("Unknown value for 'disableRootLogin' in builder [ami]", printer.ERROR)
-            return None, None, None
+            printer.out("Unknown value for 'disableRootLogin' in builder [aws]", printer.ERROR)
+            return None, None
         myrootUser.disablePasswordLogin = val
         installProfile.rootUser = myrootUser
-
-    if "updateAWSTools" in builder:
-        image.update
-
-    if "ebs" in builder:
-        if "installation" in builder and "diskSize" in builder["installation"]:
-            installProfile.ebsVolumeSize = builder["installation"]["diskSize"]
-        else:
-            printer.out("No disksize set for ebs volume in builder [ami]", printer.ERROR)
-            return None, None, None
 
     image.compress = False
     return image, installProfile

--- a/tests/integration/test.py
+++ b/tests/integration/test.py
@@ -140,6 +140,7 @@ class TestTemplate(unittest.TestCase):
                 template.set_globals(api, login, password)
                 id = get_template_id(template, "templateFull")
                 r = template.do_export("--id "+id)
+                os.remove("archive.tar.gz")
                 self.assertEqual(r, 0)
 
 


### PR DESCRIPTION
- Change "generate_ami" method to "generate_aws".
- Modify parameter check logic.
- - Now only "EBS backed" image is supported.
- - Account is not required while the generation.
- Remove ebs and account description from doc. They are not used now ("account" description is in publish section).
- Add an file removal in test.py, so that the directry become clean after the launch.

