### PR TITLE
Fix #129 A name including a space cannot be specified with hammr temp…

### DIFF
--- a/src/hammr/commands/account/account.py
+++ b/src/hammr/commands/account/account.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import shlex
 from texttable import Texttable
 from ussclicore.argumentParser import ArgumentParser, ArgumentParserError
 from ussclicore.cmd import Cmd, CoreGlobal
@@ -73,7 +74,7 @@ class Account(Cmd, CoreGlobal):
         try:
             # add arguments
             doParser = self.arg_create()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -159,7 +160,7 @@ class Account(Cmd, CoreGlobal):
         try:
             # add arguments
             doParser = self.arg_delete()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:

--- a/src/hammr/commands/bundle/bundle.py
+++ b/src/hammr/commands/bundle/bundle.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import shlex
 from texttable import Texttable
 from ussclicore.argumentParser import ArgumentParser, ArgumentParserError
 from ussclicore.cmd import Cmd, CoreGlobal
@@ -72,7 +73,7 @@ class Bundle(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_delete()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:

--- a/src/hammr/commands/image/image.py
+++ b/src/hammr/commands/image/image.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import time
+import shlex
 from hurry.filesize import size
 
 from texttable import Texttable
@@ -112,7 +113,7 @@ class Image(Cmd, CoreGlobal):
         try:
             # add arguments
             doParser = self.arg_publish()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -209,7 +210,7 @@ class Image(Cmd, CoreGlobal):
             # add arguments
             doParser = self.arg_delete()
             try:
-                doArgs = doParser.parse_args(args.split())
+                doArgs = doParser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
             # call UForge API
@@ -263,7 +264,7 @@ class Image(Cmd, CoreGlobal):
             # add arguments
             doParser = self.arg_cancel()
             try:
-                doArgs = doParser.parse_args(args.split())
+                doArgs = doParser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
             # call UForge API
@@ -324,7 +325,7 @@ class Image(Cmd, CoreGlobal):
             # add arguments
             doParser = self.arg_download()
             try:
-                doArgs = doParser.parse_args(args.split())
+                doArgs = doParser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
             # call UForge API

--- a/src/hammr/commands/os/os.py
+++ b/src/hammr/commands/os/os.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import shlex
 from hurry.filesize import size
 
 from texttable import Texttable
@@ -90,7 +91,7 @@ class Os(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_search()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:

--- a/src/hammr/commands/scan/scan.py
+++ b/src/hammr/commands/scan/scan.py
@@ -18,6 +18,7 @@ import os.path
 import shutil
 import paramiko
 import getpass
+import shlex
 import sys
 import time
 
@@ -89,7 +90,7 @@ class Scan(Cmd, CoreGlobal):
         try:
             # add arguments
             doParser = self.arg_run()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -190,7 +191,7 @@ class Scan(Cmd, CoreGlobal):
             # add arguments
             doParser = self.arg_build()
             try:
-                doArgs = doParser.parse_args(args.split())
+                doArgs = doParser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
             # --
@@ -335,9 +336,8 @@ class Scan(Cmd, CoreGlobal):
         try:
             # add arguments
             doParser = self.arg_import()
-            # doParser.add_argument('--org', dest='org', required=False)
             try:
-                doArgs = doParser.parse_args(args.split())
+                doArgs = doParser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
 
@@ -421,7 +421,7 @@ class Scan(Cmd, CoreGlobal):
         try:
             doParser = self.arg_delete()
             try:
-                doArgs = doParser.parse_args(args.split())
+                doArgs = doParser.parse_args(shlex.split(args))
             except SystemExit as e:
                 return
             # call UForge API

--- a/src/hammr/commands/template/template.py
+++ b/src/hammr/commands/template/template.py
@@ -19,6 +19,7 @@ import os.path
 import ntpath
 import shutil
 import json
+import shlex
 from junit_xml import TestSuite, TestCase
 
 from texttable import Texttable
@@ -96,7 +97,7 @@ class Template(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_export()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -163,7 +164,7 @@ class Template(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_import()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -193,7 +194,7 @@ class Template(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_validate()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -233,7 +234,7 @@ class Template(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_create()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -373,7 +374,7 @@ class Template(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_build()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -616,7 +617,7 @@ class Template(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_delete()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -666,7 +667,7 @@ class Template(Cmd, CoreGlobal):
         try:
             #add arguments
             doParser = self.arg_clone()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:
@@ -677,7 +678,7 @@ class Template(Cmd, CoreGlobal):
             myAppliance = appliance()
             myAppliance.name = doArgs.name
             myAppliance.version = doArgs.version
-            rAppliance = self.api.Users(self.login).Appliances(doArgs.id).Clones.Clone(myAppliance)
+            rAppliance = self.clone_appliance(doArgs.id, myAppliance)
             if type(rAppliance) is Appliance:
                 printer.out("Clonned successfully", printer.OK)
             else:
@@ -688,6 +689,8 @@ class Template(Cmd, CoreGlobal):
         except Exception as e:
             return handle_uforge_exception(e)
 
+    def clone_appliance(self, id, appliance):
+        return self.api.Users(self.login).Appliances(id).Clones.Clone(appliance)
 
     def help_clone(self):
         doParser = self.arg_clone()

--- a/src/hammr/hammr.py
+++ b/src/hammr/hammr.py
@@ -28,6 +28,7 @@ import getpass
 import os
 import json
 import sys
+import shlex
 
 
 from ussclicore.cmd import Cmd, CmdUtils
@@ -90,7 +91,7 @@ class Hammr(Cmd):
     def do_batch(self, args):
         try:
             doParser = self.arg_batch()
-            doArgs = doParser.parse_args(args.split())
+            doArgs = doParser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
             if not doArgs:

--- a/tests/unit/hammr/__init__.py
+++ b/tests/unit/hammr/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 UShareSoft SAS, All rights reserved
+#
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/tests/unit/hammr/commands/__init__.py
+++ b/tests/unit/hammr/commands/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 UShareSoft SAS, All rights reserved
+#
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/tests/unit/hammr/commands/template/__init__.py
+++ b/tests/unit/hammr/commands/template/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 UShareSoft SAS, All rights reserved
+#
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/tests/unit/hammr/commands/template/test_template.py
+++ b/tests/unit/hammr/commands/template/test_template.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2007-2016 UShareSoft SAS, All rights reserved
+#
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from unittest import TestCase
+
+from uforge.objects.uforge import *
+from hammr.commands.template import template
+from mock import MagicMock
+
+
+class TestTemplate(TestCase):
+    def test_do_clone_should_split_parameters_even_with_spaces(self):
+        # given
+        t = template.Template()
+        name = "my new name wit spaces"
+        args = "--id 42 --name '%s' --version 1.0" % name
+        t.clone_appliance = MagicMock(return_value=appliance())
+
+        # when
+        t.do_clone(args)
+
+        # then
+        self.assertEqual(t.clone_appliance.call_count, 1)
+        self.assertEqual(t.clone_appliance.call_args[0][1].name, name)


### PR DESCRIPTION
…late clone

 - args were splitted on spaces
 - use shlex instead
 - fix everywere args were splitted