### PR TITLE
Optional parameter for ssh port

### DIFF
--- a/src/hammr/commands/scan/scan.py
+++ b/src/hammr/commands/scan/scan.py
@@ -77,6 +77,8 @@ class Scan(Cmd, CoreGlobal):
         mandatory.add_argument('--name', dest='name', required=True,
                                help="the scan name to use when creating the scan meta-data")
         optional = doParser.add_argument_group("optional arguments")
+        optional.add_argument('--scan-port', dest='port', required=False,
+                              help="the ssh port of the running system")
         optional.add_argument('--scan-password', dest='password', required=False,
                               help="the root password to authenticate to the running system")
         optional.add_argument('--dir', dest='dir', required=False,
@@ -504,6 +506,10 @@ class Scan(Cmd, CoreGlobal):
             passW = getpass.getpass('Password for %s@%s: ' % (username, hostname))
         else:
             passW = args.password
+        if not args.port:
+            port = 22
+        else:
+            port = int(args.port)
 
         # paramiko.util.log_to_file('/tmp/ssh.log') # sets up logging
 
@@ -532,7 +538,7 @@ class Scan(Cmd, CoreGlobal):
                 dir = "/tmp"
             else:
                 dir = args.dir
-            t = paramiko.Transport((hostname, 22))
+            t = paramiko.Transport((hostname, port))
             t.connect(username=username, password=passW, hostkey=hostkey)
             sftp = paramiko.SFTPClient.from_transport(t)
 
@@ -543,7 +549,7 @@ class Scan(Cmd, CoreGlobal):
             client = paramiko.SSHClient()
             client.load_system_host_keys()
             client.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy())
-            client.connect(hostname, 22, username, passW)
+            client.connect(hostname, port, username, passW)
 
             # test service
             stdin, stdout, stderr = client.exec_command(


### PR DESCRIPTION
The default ssh port "22" was hard coded in hammr scan run command.
I add an optional parameter "--scan-port" to allow to use another one.
I haven't fully tested the functionality.
(I need this option because I use a port redirection to connect to ssh server of the vm hosted on my computer and attached to VirtualBox NAT) 