### PR TITLE
Update Hammr CLI according to new distrib profile implementation

### DIFF
--- a/hammr/commands/os/os.py
+++ b/hammr/commands/os/os.py
@@ -53,7 +53,7 @@ class Os(Cmd, CoreGlobal):
                 distributions = generics_utils.order_list_object_by(distributions.distribution, "name")
                 for distribution in distributions:
                     profiles = self.api.Distributions(distribution.dbId).Profiles.Getall()
-                    profiles = profiles.distribProfileTemplates.distribProfileTemplate
+                    profiles = profiles.distribProfiles.distribProfile
                     if len(profiles) > 0:
                         profile_text=""
                         for profile in profiles:


### PR DESCRIPTION
Now UForge is having two distrib profiles : one for linux and the other one for windows.
The DistribProfileTemplate is renamed in DistribProfile.