### PR TITLE
Fix #167 Add Fujitsu K5 publish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Hammr supports the following platforms and machine image formats:
 * VMware : Desktop (Workstation, Fusion, Player); vSphere vCenter; vCloud Director
 * Microsoft Azure
 * Google Compute Engine
+* Fujitsu K5
 * Flexiant
 * SuseCloud
 * CloudStack

--- a/documentation/en/source/pages/templates-spec/builders/builders-k5.rst
+++ b/documentation/en/source/pages/templates-spec/builders/builders-k5.rst
@@ -1,0 +1,237 @@
+.. Copyright (c) 2007-2017 UShareSoft, All rights reserved
+
+.. _builder-k5:
+
+Fujitsu K5
+==========
+
+Default builder type: ``Fujitsu K5``
+
+Require Cloud Account: Yes
+
+`www.fujitsu.com/global/solutions/cloud/k5 <http://www.fujitsu.com/global/solutions/cloud/k5/>`_
+
+The K5 builder provides information for building and publishing the machine image to the Fujitsu K5 cloud platform. This builder supports only VMDK (``Fujitsu K5``) based images for K5.
+This builder type is the default name provided by UForge AppCenter.
+
+.. note:: This builder type name can be changed by your UForge administrator. To get the available builder type, please refer to :ref:`command-line-format`.
+
+The K5 builder requires cloud account information to upload and register the machine image to the K5 platform.
+
+The K5 builder section has the following definition when using YAML:
+
+.. code-block:: yaml
+
+  ---
+  builders:
+  - type: Fujitsu K5
+    # the rest of the definition goes here.
+
+If you are using JSON:
+
+.. code-block:: javascript
+
+	{
+	  "builders": [
+	    {
+	      "type": "Fujitsu K5",
+	      ...the rest of the definition goes here.
+	    }
+	  ]
+	}
+
+Building a Machine Image
+------------------------
+
+For building an image, the valid keys are:
+
+* ``type`` (mandatory): a string providing the machine image type to build. Default builder type for K5: ``Fujitsu K5``. To get the available builder type, please refer to :ref:`command-line-format`.
+* ``diskSize`` (mandatory): an integer providing the disk size of the machine image to create. Note, this overrides any disk size information in the stack. This cannot be used if an advanced partitioning table is defined in the stack.
+
+Publishing a Machine Image
+--------------------------
+
+To publish an image, the valid keys are:
+
+* ``type`` (mandatory): a string providing the machine image type to build. Default builder type for K5: ``Fujitsu K5``. To get the available builder type, please refer to :ref:`command-line-format`.
+* ``account`` (mandatory): an object providing the K5 cloud account information required to publish the built machine image.
+* ``displayName`` (mandatory): a string providing the name of the image that will be displayed.
+* ``domain`` (mandatory): a string providing the K5 domain to publish this machine image to.
+* ``project`` (mandatory): a string providing the K5 project to publish this machine image to.
+* ``region`` (mandatory): a string providing the region where to publish the machine image. See below for valid regions.
+
+Valid Regions
+-------------
+
+The following regions are supported:
+
+* ``uk-1``: United Kingdom Region 1
+* ``jp-east-1``: Eastern Japan Region 1
+* ``jp-west-1``: Western Japan Region 1
+* ``jp-west-2``: Western Japan Region 2
+
+K5 Cloud Account
+-----------------------
+
+Key: ``account``
+
+Used to authenticate the K5 platform.
+
+The K5 cloud account has the following valid keys:
+
+* ``type`` (mandatory): a string providing the cloud account type. Default platform type for K5 is ``K5``. To get the available platform type, please refer to :ref:`command-line-platform`
+* ``name`` (mandatory): a string providing the name of the cloud account. This name can be used in a builder section to reference the rest of the cloud account information.
+* ``login`` (mandatory): a string providing the user for authenticating to keystone for publishing images
+* ``password`` (mandatory): a string providing the password for authenticating to keystone for publishing images
+* ``file`` (optional): a string providing the location of the account information. This can be a pathname (relative or absolute) or an URL.
+
+.. note:: In the case where ``name`` or ``file`` is used to reference a cloud account, all the other keys are no longer required in the account definition for the builder.
+
+
+Example
+-------
+
+The following example shows a K5 builder with all the information to build and publish a machine image to K5.
+
+If you are using YAML:
+
+.. code-block:: yaml
+
+  ---
+  builders:
+  - type: Fujitsu K5
+    account:
+      type: K5
+      name: My K5 Account
+      login: mylogin
+      password: mypassword
+    displayName: K5_testHammr
+    domain: mydomain
+    project: myproject
+    region: uk-1
+
+If you are using JSON:
+
+.. code-block:: json
+
+  {
+    "builders": [
+      {
+        "type": "Fujitsu K5",
+        "account": {
+          "type": "K5",
+          "name": "My K5 Account",
+          "login": "mylogin",
+          "password": "mypassword"
+        },
+        "displayName": "K5_testHammr",
+        "domain": "mydomain",
+        "project": "myproject",
+        "region": "uk-1"
+      }
+    ]
+  }
+
+Referencing the Cloud Account
+-----------------------------
+
+To help with security, the cloud account information can be referenced by the builder section. This example is the same as the previous example but with the account information in another file. Create a YAML file ``k5-account.yml``.
+
+.. code-block:: yaml
+
+  ---
+  accounts:
+  - type: K5
+    name: My K5 Account
+    login: mylogin
+    password: mypassword
+
+
+If you are using JSON, create a JSON file ``k5-account.json``:
+
+.. code-block:: json
+
+  {
+    "accounts": [
+      {
+        "type": "K5",
+        "name": "My K5 Account",
+        "login": "mylogin",
+        "password": "mypassword"
+      }
+    ]
+  }
+
+
+
+The builder section can either reference by using ``file`` or ``name``.
+
+Reference by file:
+
+If you are using YAML:
+
+.. code-block:: yaml
+
+  ---
+  builders:
+  - type: Fujitsu K5
+    account:
+      file: "/path/to/k5-account.yml"
+    displayName: K5_testHammr
+    domain: mydomain
+    project: myproject
+    region: uk-1
+
+If you are using JSON:
+
+.. code-block:: json
+
+  {
+    "builders": [
+      {
+        "type": "Fujitsu K5",
+        "account": {
+              "file": "/path/to/k5-account.json"
+        },
+        "displayName": "K5_testHammr",
+        "domain": "mydomain",
+        "project": "myproject",
+        "region": "uk-1"
+      }
+    ]
+  }
+
+Reference by name, note the cloud account must already be created by using ``account create``.
+
+If you are using YAML:
+
+.. code-block:: yaml
+
+  ---
+  builders:
+  - type: Fujitsu K5
+    account:
+      name: My K5 Account
+    displayName: K5_testHammr
+    domain: mydomain
+    project: myproject
+    region: uk-1
+
+If you are using JSON:
+
+.. code-block:: json
+
+  {
+    "builders": [
+      {
+        "type": "Fujitsu K5",
+        "account": {
+          "name": "My K5 Account"
+          },
+        "displayName": "K5_testHammr",
+        "domain": "mydomain",
+        "project": "myproject",
+        "region": "uk-1"
+      }
+    ]
+  }

--- a/documentation/en/source/pages/templates-spec/builders/overview.rst
+++ b/documentation/en/source/pages/templates-spec/builders/overview.rst
@@ -32,6 +32,7 @@ Cloud Targets
    builders-flexiant
    builders-gce
    builders-azure
+   builders-k5
    builders-nimbula
    builders-openstack
    builders-outscale
@@ -64,4 +65,3 @@ Physical Targets
    :titlesonly:
 
    builders-iso
-

--- a/hammr/utils/account_utils.py
+++ b/hammr/utils/account_utils.py
@@ -454,6 +454,23 @@ def outscale(account):
     myCredAccount.name = account["name"]
     return myCredAccount
 
+def k5(account):
+    myCredAccount = CredAccountK5()
+    # doing field verification
+    if not "name" in account:
+        printer.out("name for K5 account not found", printer.ERROR)
+        return
+    if not "login" in account:
+        printer.out("login in K5 account not found", printer.ERROR)
+        return
+    if not "password" in account:
+        printer.out("password in K5 account not found", printer.ERROR)
+        return
+
+    myCredAccount.name = account["name"]
+    myCredAccount.login = account["login"]
+    myCredAccount.password = account["password"]
+    return myCredAccount
 
 def get_target_platform_object(api, login, targetPlatformName):
     targetPlatformsUser = api.Users(login).Targetplatforms.Getall()

--- a/hammr/utils/generate_utils.py
+++ b/hammr/utils/generate_utils.py
@@ -201,6 +201,9 @@ def generate_outscale(image, builder, installProfile, api, login):
     image.compress = False
     return image, installProfile
 
+def generate_k5vmdk(image, builder, installProfile, api, login):
+    image.compress = False
+    return image, installProfile
 
 ##--------------------- Physical Formats
 def generate_iso(image, builder, installProfile, api=None, login=None):

--- a/hammr/utils/publish_utils.py
+++ b/hammr/utils/publish_utils.py
@@ -347,3 +347,27 @@ def publish_outscale(pimage, builder):
 
     pimage.credAccount.zoneName = builder["zone"]
     return pimage
+
+def publish_k5vmdk(builder):
+    pimage = PublishImageK5()
+
+    # doing field verification
+    if not "displayName" in builder:
+        printer.out("displayName in k5 builder not found", printer.ERROR)
+        return
+    if not "domain" in builder:
+        printer.out("domain in k5 builder not found", printer.ERROR)
+        return
+    if not "project" in builder:
+        printer.out("project in k5 builder not found", printer.ERROR)
+        return
+    if not "region" in builder:
+        printer.out("region in k5 builder not found", printer.ERROR)
+        return
+
+    pimage.displayName = builder["displayName"]
+    pimage.keystoneDomain = builder["domain"]
+    pimage.keystoneProject = builder["project"]
+    pimage.publishLocation = builder["region"]
+
+    return pimage

--- a/tests/unit/utils/test_account_utils.py
+++ b/tests/unit/utils/test_account_utils.py
@@ -1,0 +1,72 @@
+# Copyright 2007-2017 UShareSoft SAS, All rights reserved
+#
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from unittest import TestCase
+
+from hammr.utils.account_utils import *
+
+
+class TestK5(TestCase):
+    def test_k5_should_return_cred_account_when_valid_entries(self):
+        # given
+        account_given = self.build_account("testName", "testLogin", "testPassword")
+
+        # when
+        account = k5(account_given)
+
+        # then
+        self.assertEqual(account.name, account_given["name"])
+        self.assertEqual(account.login, account_given["login"])
+        self.assertEqual(account.password, account_given["password"])
+
+
+    def test_k5_should_return_none_when_missing_name(self):
+        # given
+        account_given = self.build_account(None, "testLogin", "testPassword")
+
+        # when
+        account = k5(account_given)
+
+        # then
+        self.assertIsNone(account)
+
+
+    def test_k5_should_return_none_when_missing_login(self):
+        # given
+        account_given = self.build_account("testName", None, "testPassword")
+
+        # when
+        account = k5(account_given)
+
+        # then
+        self.assertIsNone(account)
+
+
+    def test_k5_should_return_none_when_missing_password(self):
+        # given
+        account_given = self.build_account("testName", "testLogin", None)
+
+        # when
+        account = k5(account_given)
+
+        # then
+        self.assertIsNone(account)
+
+
+    def build_account(self, name, login, password):
+        account = {}
+        if name is not None: account["name"] = name
+        if login is not None: account["login"] = login
+        if password is not None: account["password"] = password
+        return account

--- a/tests/unit/utils/test_generate_utils.py
+++ b/tests/unit/utils/test_generate_utils.py
@@ -1,0 +1,58 @@
+# Copyright 2007-2017 UShareSoft SAS, All rights reserved
+#
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from unittest import TestCase
+
+from hammr.utils.generate_utils import *
+
+class TestGenerateK5(TestCase):
+    def test_generate_k5vmdk_should_return_uncompressed_image_given_compressed_image(self):
+        # given
+        image_given = CompressedImage()
+        intall_profile_given = MockObject()
+
+        # when
+        image, install_profile = generate_k5vmdk(image_given, WhateverObject(), intall_profile_given, WhateverObject(), WhateverObject())
+
+        # then
+        self.assertFalse(image.compress)
+        self.assertEquals(intall_profile_given, install_profile)
+
+
+    def test_generate_k5vmdk_should_return_uncompressed_image_given_uncompressed_image(self):
+        # given
+        image_given = UncompressedImage()
+        intall_profile_given = MockObject()
+
+        # when
+        image, install_profile = generate_k5vmdk(image_given, WhateverObject(), intall_profile_given,
+                                                 WhateverObject(), WhateverObject())
+
+        # then
+        self.assertFalse(image.compress)
+        self.assertEquals(intall_profile_given, install_profile)
+
+
+class CompressedImage:
+    compress = True
+
+class UncompressedImage:
+    compress = False
+
+class MockObject:
+    first_attribute = "something"
+    second_attribute = "something else"
+
+class WhateverObject:
+    whatever = "whatever"

--- a/tests/unit/utils/test_publish_utils.py
+++ b/tests/unit/utils/test_publish_utils.py
@@ -1,0 +1,85 @@
+# Copyright 2007-2017 UShareSoft SAS, All rights reserved
+#
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from unittest import TestCase
+
+from hammr.utils.publish_utils import *
+
+
+class TestPublishK5(TestCase):
+    def test_publish_k5_should_return_publish_image_when_valid_entries(self):
+        # given
+        builder = self.build_builder("testName", "testDomain", "testProject", "testRegion")
+
+        # when
+        pimage = publish_k5vmdk(builder)
+
+        # then
+        self.assertEqual(pimage.displayName, builder["displayName"])
+        self.assertEqual(pimage.keystoneDomain, builder["domain"])
+        self.assertEqual(pimage.keystoneProject, builder["project"])
+        self.assertEqual(pimage.publishLocation, builder["region"])
+
+
+    def test_publish_k5_should_return_none_when_missing_name(self):
+        # given
+        builder = self.build_builder(None, "testDomain", "testProject", "testRegion")
+
+        # when
+        pimage = publish_k5vmdk(builder)
+
+        # then
+        self.assertIsNone(pimage)
+
+
+    def test_publish_k5_should_return_none_when_missing_domain(self):
+        # given
+        builder = self.build_builder("testName", None, "testProject", "testRegion")
+
+        # when
+        pimage = publish_k5vmdk(builder)
+
+        # then
+        self.assertIsNone(pimage)
+
+
+    def test_publish_k5_should_return_none_when_missing_project(self):
+        # given
+        builder = self.build_builder("testName", "testDomain", None, "testRegion")
+
+        # when
+        pimage = publish_k5vmdk(builder)
+
+        # then
+        self.assertIsNone(pimage)
+
+
+    def test_publish_k5_should_return_none_when_missing_region(self):
+        # given
+        builder = self.build_builder("testName", "testDomain", "testProject", None)
+
+        # when
+        pimage = publish_k5vmdk(builder)
+
+        # then
+        self.assertIsNone(pimage)
+
+
+    def build_builder(self, name, domain, project, region):
+        builder = {}
+        if name is not None: builder["displayName"] = name
+        if domain is not None: builder["domain"] = domain
+        if project is not None: builder["project"] = project
+        if region is not None: builder["region"] = region
+        return builder


### PR DESCRIPTION
Add support for the new K5 connector introduced in **3.6-fp1**.
_Warn: needs a python-sdk built from **3.6-fp1** at least._ 
@segalaj: should be pretty similar to #166, could you kindly review it?