### PR TITLE
Gives an optional parameter in method download

### DIFF
--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -341,7 +341,7 @@ class Image(Cmd, CoreGlobal):
                         dlImage = image
                 if dlImage is not None and dlImage.status.complete and not dlImage.status.error and dlImage.compress:
                     download_url = self.api.getUrl() + "/" + dlImage.downloadUri
-                    dlUtils = download_utils.Download(download_url, doArgs.file)
+                    dlUtils = download_utils.Download(download_url, doArgs.file, not self.api.getDisableSslCertificateValidation())
                     try:
                         dlUtils.start()
                     except Exception, e:

--- a/hammr/commands/scan/scan.py
+++ b/hammr/commands/scan/scan.py
@@ -108,7 +108,7 @@ class Scan(Cmd, CoreGlobal):
             os.mkdir(constants.TMP_WORKING_DIR)
             local_uforge_scan_path = constants.TMP_WORKING_DIR + os.sep + constants.SCAN_BINARY_NAME
 
-            dlUtils = download_utils.Download(download_url, local_uforge_scan_path)
+            dlUtils = download_utils.Download(download_url, local_uforge_scan_path, not self.api.getDisableSslCertificateValidation())
             try:
                 dlUtils.start()
             except Exception, e:


### PR DESCRIPTION
This parameter has a default value in the method definition (see [here](https://github.com/usharesoft/hammr/issues/58) ). This commit allows to take into account the value given to hammr in the credential file.