### PR TITLE
fix #52 Complete error message when account is not found on the platform

### DIFF
--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -520,7 +520,7 @@ class Image(Cmd, CoreGlobal):
         accounts = self.api.Users(self.login).Accounts.Getall()
         accounts = accounts.credAccounts.credAccount
         if accounts is None or len(accounts) == 0:
-            printer.out("No accounts available on the plateform", printer.ERROR)
+            printer.out("No accounts available on the plateform.\n You can use the command 'hammr account create' to create an account.", printer.ERROR)
             return 2
         else:
             for account in accounts:
@@ -541,7 +541,7 @@ class Image(Cmd, CoreGlobal):
                     return account
                     break
 
-            printer.out("No accounts available with name " + builder["account"]["name"], printer.ERROR)
+            printer.out("No accounts available with name " + builder["account"]["name"] + ".\nYou can use the command 'hammr account create' to create an account.", printer.ERROR)
             return 2
 
     # get the account name from field or from the credential file given in the builder


### PR DESCRIPTION
This [issue](https://github.com/usharesoft/hammr/issues/52) talks about an error that is supposed to happen ([documentation](http://docs.usharesoft.com/projects/hammr/en/latest/pages/templates-spec/builders/overview.html#template-builders)) : before making a publish with hammr, we need to create an account.

This commit complete the error message to give the user more indication when he sees this error.