### PR TITLE
A scan name including a space cannot be specified with hammr scan run…

### DIFF
--- a/hammr/commands/scan/scan.py
+++ b/hammr/commands/scan/scan.py
@@ -569,7 +569,7 @@ class Scan(Cmd, CoreGlobal):
             if args.overlay:
                 overlay = "-o"
             client.exec_command(
-                'chmod +x ' + dir + '/' + constants.SCAN_BINARY_NAME + '; nohup ' + dir + '/' + constants.SCAN_BINARY_NAME + ' -u ' + uforge_login + ' -p ' + uforge_password + ' -U ' + uforge_url + ' ' + overlay + ' -n ' + args.name + ' ' + exclude + ' >/dev/null 2>&1 &')
+                'chmod +x ' + dir + '/' + constants.SCAN_BINARY_NAME + '; nohup ' + dir + '/' + constants.SCAN_BINARY_NAME + ' -u ' + uforge_login + ' -p ' + uforge_password + ' -U ' + uforge_url + ' ' + overlay + ' -n \'' + args.name + '\' ' + exclude + ' >/dev/null 2>&1 &')
             client.close()
 
         except paramiko.AuthenticationException as e:


### PR DESCRIPTION
…. #140

add quote to scan name in exec_command to take into account spaces in the scan name