### PR TITLE
Fix the "Could not import extension rst2pdf.pdfbuilder" error in rtd

### DIFF
--- a/documentation/en/source/conf.py
+++ b/documentation/en/source/conf.py
@@ -35,9 +35,14 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.intersphinx',
-    'rst2pdf.pdfbuilder',
+if on_rtd:
+    extensions = [
+        'sphinx.ext.intersphinx',
+    ]
+else:
+    extensions = [
+        'sphinx.ext.intersphinx',
+        'rst2pdf.pdfbuilder',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Fix the "Could not import extension rst2pdf.pdfbuilder" error in readthedocs