### PR TITLE
Big cleanup on deploy

### DIFF
--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -217,46 +217,41 @@ class Image(Cmd, CoreGlobal):
     def do_deploy(self, args):
         try:
             # add arguments
-            doParser = self.arg_deploy()
-            doArgs = doParser.parse_args(shlex.split(args))
+            do_parser = self.arg_deploy()
+            do_args = do_parser.parse_args(shlex.split(args))
 
             # if the help command is called, parse_args returns None object
-            if not doArgs:
+            if not do_args:
                 return 2
 
-            publishImage = self.get_publish_image_from_publish_id(doArgs.pid)
-            if publishImage == 2:
-                return 2
+            publish_image = self.get_publish_image_from_publish_id(do_args.pid)
 
-            if not self.is_pimage_ready_to_deploy(publishImage):
-                printer.out("Published image with name '" + publishImage.name + " cannot be deployed", printer.ERROR)
-                return 2
+            if not self.is_publish_image_ready_to_deploy(publish_image):
+                raise ValueError("Published image with id '" + do_args.pid + " is not ready to be deployed")
 
-            deployFile = generics_utils.get_file(doArgs.file)
-            if deployFile is None:
-                return 2
+            deploy_file = generics_utils.get_file(do_args.file)
+            if deploy_file is None:
+                raise TypeError("Deploy file cannot be None")
 
-            imageId = generics_utils.extract_id(publishImage.imageUri)
-            if imageId is None or imageId == "":
-                printer.out("Image not found", printer.ERROR)
-                return 2
+            if publish_image.targerFormat is None:
+                raise TypeError("Publish image target format cannot be None")
 
-            targetPlatform = publishImage.targetFormat.name
-            if "Amazon" in targetPlatform:
-                return self.deploy_aws(deployFile, publishImage)
+            target_plateform_name = publish_image.targetFormat.name
+            if "Amazon" in target_plateform_name:
+                return self.deploy_aws(deploy_file, publish_image)
 
-            elif "OpenStack" in targetPlatform:
-                return self.deploy_openstack(deployFile, publishImage)
+            elif "OpenStack" in target_plateform_name:
+                return self.deploy_openstack(deploy_file, publish_image)
 
-            elif "Azure" in targetPlatform:
-                return self.deploy_azure(deployFile, publishImage)
+            elif "Azure" in target_plateform_name:
+                return self.deploy_azure(deploy_file, publish_image)
 
             else:
                 printer.out("Hammr only supports deployments for Amazon AWS, OpenStack and Microsoft Azure ARM.",
                             printer.ERROR)
                 return 2
 
-        except TypeError as e:
+        except (TypeError, ValueError) as e:
             printer.out(str(e), printer.ERROR)
             return 2
 
@@ -552,8 +547,8 @@ class Image(Cmd, CoreGlobal):
 
         return True
 
-    def is_pimage_ready_to_deploy(self, pimage):
-        if not pimage.status.complete or pimage.status.error or pimage.status.cancelled:
+    def is_publish_image_ready_to_deploy(self, publishImage):
+        if not publishImage.status.complete or publishImage.status.error or publishImage.status.cancelled:
             return False
 
         return True
@@ -658,20 +653,22 @@ class Image(Cmd, CoreGlobal):
                 account_name = account["name"]
         return account_name
 
-    def get_publish_image_from_publish_id(self, id):
-        pimages = self.api.Users(self.login).Pimages.Getall()
-        pimages = pimages.publishImages.publishImage
-        pimage = None
-        if pimages is None or len(pimages) == 0:
-            printer.out("No published images available")
+    def get_publish_image_from_publish_id(self, publish_id):
+        publish_images = self.api.Users(self.login).Pimages.Getall()
+        publish_images = publish_images.publishImages.publishImage
+
+        if publish_images is None or len(publish_images) == 0:
+            raise TypeError("No published images available")
+
+        publish_image = None
+        for p in publish_images:
+            if str(p.dbId) == str(publish_id):
+                publish_image = p
+
+        if publish_image is None:
+            raise TypeError("Published image not found")
         else:
-            for piimage in pimages:
-                if str(piimage.dbId) == str(id):
-                    pimage = piimage
-        if pimage is None:
-            printer.out("published image not found", printer.ERROR)
-            return 2
-        return pimage
+            return publish_image
 
     def deploy_aws(self, deployFile, publishImage):
         attributes = check_and_get_attributes_from_file(deployFile, ["name"])

--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -231,10 +231,10 @@ class Image(Cmd, CoreGlobal):
 
             deploy_file = generics_utils.get_file(do_args.file)
             if deploy_file is None:
-                raise TypeError("Deploy file cannot be None")
+                raise TypeError("Deploy file not found")
 
             if publish_image.targetFormat is None:
-                raise TypeError("Publish image target format cannot be None")
+                raise TypeError("Publish image target format not found")
 
             target_plateform_name = publish_image.targetFormat.name
             if "Amazon" in target_plateform_name:

--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -233,7 +233,7 @@ class Image(Cmd, CoreGlobal):
             if deploy_file is None:
                 raise TypeError("Deploy file cannot be None")
 
-            if publish_image.targerFormat is None:
+            if publish_image.targetFormat is None:
                 raise TypeError("Publish image target format cannot be None")
 
             target_plateform_name = publish_image.targetFormat.name
@@ -704,6 +704,7 @@ class Image(Cmd, CoreGlobal):
         attributes = check_and_get_attributes_from_file(deploy_file, ["name", "userName"])
 
         deployment = build_deployment_azure(attributes)
+
         deployed_instance = call_deploy(self, publish_image, deployment)
 
         deployed_instance_id = deployed_instance.applicationId

--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -670,44 +670,42 @@ class Image(Cmd, CoreGlobal):
         else:
             return publish_image
 
-    def deploy_aws(self, deployFile, publishImage):
-        attributes = check_and_get_attributes_from_file(deployFile, ["name"])
-        imageId = generics_utils.extract_id(publishImage.imageUri)
+    def deploy_aws(self, deploy_file, publish_image):
+        attributes = check_and_get_attributes_from_file(deploy_file, ["name"])
 
         deployment = build_deployment_amazon(attributes)
-        deployedInstance = call_deploy(self, publishImage, deployment, imageId)
 
-        deployedInstanceId = deployedInstance.applicationId
-        status = show_deploy_progress_without_percentage(self, deployedInstanceId)
-        return print_deploy_info(self, status, deployedInstanceId)
+        deployed_instance = call_deploy(self, publish_image, deployment)
 
-    def deploy_openstack(self, deployFile, publishImage):
-        attributes = check_and_get_attributes_from_file(deployFile, ["name", "region", "network", "flavor"])
+        deployed_instance_id = deployed_instance.applicationId
+        status = show_deploy_progress_without_percentage(self, deployed_instance_id)
+        return print_deploy_info(self, status, deployed_instance_id)
+
+    def deploy_openstack(self, deploy_file, publish_image):
+        attributes = check_and_get_attributes_from_file(deploy_file, ["name", "region", "network", "flavor"])
 
         bar_status = OpStatus()
         progress = create_progress_bar_openstack(bar_status)
 
-        cred_account = retrieve_credaccount(self, publishImage.dbId, publishImage)
-        deployment = build_deployment_openstack(attributes, publishImage, cred_account)
+        cred_account = retrieve_credaccount(self, publish_image.dbId, publish_image)
+        deployment = build_deployment_openstack(attributes, publish_image, cred_account)
 
         bar_status.message = "Deploying instance"
         bar_status.percentage = 50
         progress.update(bar_status.percentage)
 
-        imageId = generics_utils.extract_id(publishImage.imageUri)
-        deployedInstance = call_deploy(self, publishImage, deployment, imageId)
+        deployed_instance = call_deploy(self, publish_image, deployment)
 
-        deployedInstanceId = deployedInstance.applicationId
-        status = show_deploy_progress_with_percentage(self, deployedInstanceId, bar_status, progress)
-        return print_deploy_info(self, status, deployedInstanceId)
+        deployed_instance_id = deployed_instance.applicationId
+        status = show_deploy_progress_with_percentage(self, deployed_instance_id, bar_status, progress)
+        return print_deploy_info(self, status, deployed_instance_id)
 
-    def deploy_azure(self, deployFile, publishImage):
-        attributes = check_and_get_attributes_from_file(deployFile, ["name", "userName"])
+    def deploy_azure(self, deploy_file, publish_image):
+        attributes = check_and_get_attributes_from_file(deploy_file, ["name", "userName"])
 
         deployment = build_deployment_azure(attributes)
-        imageId = generics_utils.extract_id(publishImage.imageUri)
-        deployedInstance = call_deploy(self, publishImage, deployment, imageId)
+        deployed_instance = call_deploy(self, publish_image, deployment)
 
-        deployedInstanceId = deployedInstance.applicationId
-        status = show_deploy_progress_without_percentage(self, deployedInstanceId)
-        return print_deploy_info(self, status, deployedInstanceId)
+        deployed_instance_id = deployed_instance.applicationId
+        status = show_deploy_progress_without_percentage(self, deployed_instance_id)
+        return print_deploy_info(self, status, deployed_instance_id)

--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -673,7 +673,7 @@ class Image(Cmd, CoreGlobal):
     def deploy_aws(self, deploy_file, publish_image):
         attributes = check_and_get_attributes_from_file(deploy_file, ["name"])
 
-        deployment = build_deployment_amazon(attributes)
+        deployment = build_deployment_aws(attributes)
 
         deployed_instance = call_deploy(self, publish_image, deployment)
 

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -165,56 +165,32 @@ def retrieve_openstack_resources(region_name, network_name, flavor_name, publish
 
 
 def retrieve_cred_account_resources_tenant(cred_account_resources, publish_image):
-    tenant = None
-    for t in cred_account_resources.cloudResources.tenants.tenant:
-        if t.name == publish_image.tenantName:
-            tenant = t
-            break
-
-    if tenant is None:
-        raise TypeError("Tenant not found")
-    else:
-        return tenant
+    for tenant in cred_account_resources.cloudResources.tenants.tenant:
+        if tenant.name == publish_image.tenantName:
+            return tenant
+    raise TypeError("Tenant not found")
 
 
 def retrieve_openstack_resources_region(region_name, tenant):
-    region = None
-    for region_entities in tenant.regionsEntities:
-        for region_entity in region_entities.regionEntities:
-            if region_entity.regionName == region_name:
-                region = region_entity
-                break
-
-    if region is None:
-        raise TypeError("Region " + region_name + " not found on OpenStack")
-    else:
-        return region
+    for region_entity in tenant.regionsEntities:
+        for region in region_entity.regionEntities:
+            if region.regionName == region_name:
+                return region
+    raise TypeError("Region " + region_name + " not found on OpenStack")
 
 
 def retrieve_openstack_resources_flavor_id(flavor_name, region):
-    flavor_id = None
     for flavor in region.flavors.flavor:
         if flavor.name == flavor_name:
-            flavor_id = flavor.id
-            break
-
-    if flavor_id is None:
-        raise TypeError("Cannot find flavor " + flavor_name + " in region " + region.regionName)
-    else:
-        return flavor_id
+            return flavor.id
+    raise TypeError("Cannot find flavor " + flavor_name + " in region " + region.regionName)
 
 
 def retrieve_openstack_resources_network_id(network_name, region):
-    network_id = None
     for network in region.networks.network:
         if network.name == network_name:
-            network_id = network.id
-            break
-
-    if network_id is None:
-        raise TypeError("Cannot find network " + network_name + " in region " + region.regionName)
-    else:
-        return network_id
+            return network.id
+    raise TypeError("Cannot find network " + network_name + " in region " + region.regionName)
 
 
 def create_progress_bar_openstack(bar_status):

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -88,36 +88,36 @@ def check_and_get_attributes_from_file(deploy_file, expected_attributes):
 
 def build_deployment_aws(attributes):
     deployment = Deployment()
-    myInstance = InstanceAmazon()
+    my_instance = InstanceAmazon()
 
     deployment.name = attributes["name"]
-    set_instance_cores_and_memory(myInstance, attributes)
+    set_instance_cores_and_memory(my_instance, attributes)
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(myInstance)
+    deployment.instances.append(my_instance)
     return deployment
 
 
 def build_deployment_azure(attributes):
     deployment = Deployment()
-    myInstance = InstanceAzureResourceManager()
+    my_instance = InstanceAzureResourceManager()
 
     deployment.name = attributes["name"]
-    myInstance.userName = attributes["userName"]
+    my_instance.userName = attributes["userName"]
 
     if "userSshKey" in attributes:
-        myInstance.userSshKey = attributes["userSshKey"]
+        my_instance.userSshKey = attributes["userSshKey"]
     elif "userSshKeyFile" in attributes:
-        myInstance.userSshKey = open(attributes["userSshKeyFile"], "r").read()
+        my_instance.userSshKey = open(attributes["userSshKeyFile"], "r").read()
     else:
-        myInstance.userPassword = query_password_azure("Please enter the password to connect to the instance: ")
+        my_instance.userPassword = query_password_azure("Please enter the password to connect to the instance: ")
 
-    set_instance_cores_and_memory(myInstance, attributes)
+    set_instance_cores_and_memory(my_instance, attributes)
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(myInstance)
+    deployment.instances.append(my_instance)
     return deployment
 
 
@@ -132,21 +132,21 @@ def set_instance_cores_and_memory(my_instance, attributes):
         my_instance.memory = attributes["memory"]
 
 
-def build_deployment_openstack(attributes, publishImage, credAccountRessources):
+def build_deployment_openstack(attributes, publish_image, cred_account_ressources):
     deployment = Deployment()
-    myInstance = InstanceOpenStack()
+    my_instance = InstanceOpenStack()
 
     deployment.name = attributes["name"]
-    myInstance.region = attributes["region"]
-    networkName = attributes["network"]
-    flavorName = attributes["flavor"]
+    my_instance.region = attributes["region"]
+    network_name = attributes["network"]
+    flavor_name = attributes["flavor"]
 
-    myInstance.networkId, myInstance.flavorId = retrieve_openstack_resources(myInstance.region, networkName,
-                                                                             flavorName, publishImage, credAccountRessources)
+    my_instance.networkId, my_instance.flavorId = retrieve_openstack_resources(my_instance.region, network_name,
+                                                                             flavor_name, publish_image, cred_account_ressources)
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(myInstance)
+    deployment.instances.append(my_instance)
     return deployment
 
 

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -91,7 +91,7 @@ def build_deployment_aws(attributes):
     myInstance = InstanceAmazon()
 
     deployment.name = attributes["name"]
-    get_instance_cores_and_memory(myInstance, attributes)
+    set_instance_cores_and_memory(myInstance, attributes)
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
@@ -113,7 +113,7 @@ def build_deployment_azure(attributes):
     else:
         myInstance.userPassword = query_password_azure("Please enter the password to connect to the instance: ")
 
-    get_instance_cores_and_memory(myInstance, attributes)
+    set_instance_cores_and_memory(myInstance, attributes)
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
@@ -121,7 +121,7 @@ def build_deployment_azure(attributes):
     return deployment
 
 
-def get_instance_cores_and_memory(my_instance, attributes):
+def set_instance_cores_and_memory(my_instance, attributes):
     if not "cores" in attributes:
         my_instance.cores = "1"
     else:

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -27,6 +27,7 @@ from texttable import Texttable
 import getpass
 import re
 
+
 def retrieve_credaccount(image_object, pimageId, pimage):
     # Increases the limit for non determinist content: the xml used for openstack retrieval has a lot of
     # non determinist content that raises an exception if limit is low.
@@ -37,12 +38,14 @@ def retrieve_credaccount(image_object, pimageId, pimage):
     else:
         return retrieve_credaccount_from_scan(image_object, pimageId, pimage)
 
+
 def retrieve_credaccount_from_app(image_object, pimageId, pimage):
     image_id = generics_utils.extract_id(pimage.imageUri)
     source_id = generics_utils.extract_id(pimage.applianceUri)
     account_id = pimage.credAccount.dbId
     return image_object.api.Users(image_object.login).Appliances(source_id).Images(image_id).Pimages(pimageId).\
         Accounts(account_id).Resources.Getaccountresources()
+
 
 def retrieve_credaccount_from_scan(image_object, pimageId, pimage):
     image_id = generics_utils.extract_id(pimage.imageUri)
@@ -51,6 +54,7 @@ def retrieve_credaccount_from_scan(image_object, pimageId, pimage):
     account_id = pimage.credAccount.dbId
     return image_object.api.Users(image_object.login).Scannedinstances(scannedinstance_id).Scans(scan_id).\
         Images(image_id).Pimages(pimageId).Accounts(account_id).Resources.Getaccountresources()
+
 
 def validate_deployment(file):
     try:
@@ -72,134 +76,144 @@ def validate_deployment(file):
     except IOError as e:
         printer.out("unknown error deployment json file", printer.ERROR)
 
-def build_deployment_amazon(data):
-    data = validate_deployment(data)
-    deployment = Deployment()
-    myinstance = InstanceAmazon()
-    if not "name" in data:
-        printer.out("There is no attribute [name] for the provisioner", printer.ERROR)
-        return None
-    deployment.name = data["name"]
-    if not "cores" in data:
-        myinstance.cores = "1"
-    else:
-        myinstance.cores = data["cores"]
-    if not "memory" in data:
-        myinstance.memory = "1024"
-    else:
-        myinstance.memory = data["memory"]
-    deployment.instances = pyxb.BIND()
-    deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(myinstance)
-    return deployment
 
-def build_deployment_azure(data):
-    data = validate_deployment(data)
-    deployment = Deployment()
-    myinstance = InstanceAzureResourceManager()
-    if not "name" in data:
-        printer.out("There is no attribute [name] for the provisioner", printer.ERROR)
-        return None
-    deployment.name = data["name"]
-    if "userName" in data:
-        myinstance.userName = data["userName"]
-    else:
-        printer.out("There is no attribute [userName] for the provisioner", printer.ERROR)
-        return None
-    if "userSshKey" in data:
-        myinstance.userSshKey = data["userSshKey"]
-    elif "userSshKeyFile" in data:
-        try:
-            myinstance.userSshKey = open(data["userSshKeyFile"], "r").read()
-        except IOError as e:
-                printer.out("File error: "+str(e), printer.ERROR)
-                return
-    else:
-        myinstance.userPassword = query_password_azure("Please enter the password to connect to the instance: ")
+def check_and_get_attributes_from_file(file, expectedAttributes):
+    attributes = validate_deployment(file)
+    for attribute in expectedAttributes:
+        if not attribute in attributes:
+            raise TypeError("There is no attribute [" + attribute + "] for the provisioner")
 
-    if not "cores" in data:
-        myinstance.cores = "1"
+    return attributes
+
+
+def build_deployment_amazon(attributes):
+    deployment = Deployment()
+    myInstance = InstanceAmazon()
+
+    deployment.name = attributes["name"]
+    if not "cores" in attributes:
+        myInstance.cores = "1"
     else:
-        myinstance.cores = data["cores"]
-    if not "memory" in data:
-        myinstance.memory = "1024"
+        myInstance.cores = attributes["cores"]
+    if not "memory" in attributes:
+        myInstance.memory = "1024"
     else:
-        myinstance.memory = data["memory"]
+        myInstance.memory = attributes["memory"]
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(myinstance)
+    deployment.instances.append(myInstance)
     return deployment
 
-def build_deployment_openstack(data, pimage, pimageId, cred_account_ressources):
-    data = validate_deployment(data)
+
+def build_deployment_azure(attributes):
     deployment = Deployment()
-    myinstance = InstanceOpenStack()
+    myInstance = InstanceAzureResourceManager()
 
-    if not "name" in data:
-        printer.out("There is no attribute [name] for the provisioner", printer.ERROR)
-        return None
-    deployment.name = data["name"]
+    deployment.name = attributes["name"]
+    myInstance.userName = attributes["userName"]
 
-    if not "region" in data:
-        printer.out("There is no attribute [region] for the provisioner", printer.ERROR)
-        return None
-    myinstance.region = data["region"]
+    if "userSshKey" in attributes:
+        myInstance.userSshKey = attributes["userSshKey"]
+    elif "userSshKeyFile" in attributes:
+        myInstance.userSshKey = open(attributes["userSshKeyFile"], "r").read()
+    else:
+        myInstance.userPassword = query_password_azure("Please enter the password to connect to the instance: ")
 
-    if not "network" in data:
-        printer.out("There is no attribute [network] for the provisioner", printer.ERROR)
-        return None
-    network_name = data["network"]
-
-    if not "flavor" in data:
-        printer.out("There is no attribute [flavor] for the provisioner", printer.ERROR)
-        return None
-    flavor_name = data["flavor"]
-
-    myinstance.networkId, myinstance.flavorId = retrieve_openstack_resources(myinstance.region, network_name,
-                                                                flavor_name, pimage, pimageId, cred_account_ressources)
+    if not "cores" in attributes:
+        myInstance.cores = "1"
+    else:
+        myInstance.cores = attributes["cores"]
+    if not "memory" in attributes:
+        myInstance.memory = "1024"
+    else:
+        myInstance.memory = attributes["memory"]
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(myinstance)
-
+    deployment.instances.append(myInstance)
     return deployment
 
-def retrieve_openstack_resources(region_name, network_name, flavor_name, pimage, pimageId, cred_account_ressources):
-    flavor_id = None
-    network_id = None
-    tenants = cred_account_ressources.cloudResources.tenants.tenant
-    tenant_name = pimage.tenantName
-    for tenant in tenants:
-        if tenant.name == tenant_name:
-            break;
 
-    region_retrieved = None
-    regionsEntities = tenant.regionsEntities
-    for regionEntities in regionsEntities:
-        regions = regionEntities.regionEntities
-        for region in regions:
-            if region.regionName == region_name:
-                region_retrieved = region
-                break;
+def build_deployment_openstack(attributes, publishImage, credAccountRessources):
+    deployment = Deployment()
+    myInstance = InstanceOpenStack()
 
-    if region_retrieved == None:
-        printer.out("Region of the published image not found", printer.ERROR)
-        return None, None
+    deployment.name = attributes["name"]
+    myInstance.region = attributes["region"]
+    networkName = attributes["network"]
+    flavorName = attributes["flavor"]
 
-    flavors = region.flavors.flavor
-    for flavor in flavors:
+    myInstance.networkId, myInstance.flavorId = retrieve_openstack_resources(myInstance.region, networkName,
+                                                                             flavorName, publishImage, credAccountRessources)
+
+    deployment.instances = pyxb.BIND()
+    deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
+    deployment.instances.append(myInstance)
+    return deployment
+
+
+def retrieve_openstack_resources(regionName, networkName, flavorName, publishImage, credAccountRessources):
+    tenant = retrieve_cred_account_ressources_tenant(credAccountRessources, publishImage)
+    region = retrieve_openstack_resources_region(regionName, tenant)
+    flavorId = retrieve_openstack_resources_flavor_id(flavorName, region)
+    networkId = retrieve_openstack_resources_network_id(networkName, region)
+
+    return networkId[0].encode('ascii', 'ignore'), flavorId.encode('ascii', 'ignore')
+
+
+def retrieve_cred_account_ressources_tenant(credAccountRessources, publishImage):
+    tenant = None
+    for t in credAccountRessources.cloudResources.tenants.tenant:
+        if t.name == publishImage.tenantName:
+            tenant = t
+            break
+
+    if tenant is None:
+        raise TypeError("Tenant not found")
+    else:
+        return tenant
+
+
+def retrieve_openstack_resources_region(region_name, tenant):
+    region = None
+    for regionEntities in tenant.regionsEntities:
+        for regionEntity in regionEntities.regionEntities:
+            if regionEntity.regionName == region_name:
+                region = regionEntity
+                break
+
+    if region is None:
+        raise TypeError("Region " + region_name + " not found on OpenStack")
+    else:
+        return region
+
+
+def retrieve_openstack_resources_flavor_id(flavor_name, region):
+    flavorId = None
+    for flavor in region.flavors.flavor:
         if flavor.name == flavor_name:
-            flavor_id = flavor.id
-            break;
+            flavorId = flavor.id
+            break
 
-    networks = region.networks.network
-    for network in networks:
+    if flavorId is None:
+        raise TypeError("Cannot find flavor " + flavor_name + " in region " + region.regionName)
+    else:
+        return flavorId
+
+
+def retrieve_openstack_resources_network_id(network_name, region):
+    networkId = None
+    for network in region.networks.network:
         if network.name == network_name:
-            network_id = network.id
-            break;
+            networkId = network.id
+            break
 
-    return network_id[0].encode('ascii', 'ignore'), flavor_id.encode('ascii', 'ignore')
+    if networkId is None:
+        raise TypeError("Cannot find network " + network_name + " in region " + region.regionName)
+    else:
+        return networkId
+
 
 def create_progress_bar_openstack(bar_status):
     bar_status.message = "Retrieving information from OpenStack"
@@ -213,27 +227,32 @@ def create_progress_bar_openstack(bar_status):
     progress.update(bar_status.percentage)
     return progress
 
-def call_deploy(image_object, pimage, deployment, image_id):
-    if is_uri_based_on_appliance(pimage.imageUri):
-        source = image_object.api.Users(image_object.login).Appliances(generics_utils.extract_id(pimage.applianceUri)).Get()
+
+def call_deploy(imageObject, publishImage, deployment, imageId):
+    if is_uri_based_on_appliance(publishImage.imageUri):
+        source = imageObject.api.Users(imageObject.login).Appliances(
+            generics_utils.extract_id(publishImage.applianceUri)).Get()
+
         if source is None or not hasattr(source, 'dbId'):
-            printer.out("No template found for this image", printer.ERROR)
-            return 2
-        deployed_instance = image_object.api.Users(image_object.login).Appliances(source.dbId).Images(image_id).Pimages(
-            pimage.dbId).Deploys.Deploy(body=deployment, element_name="ns1:deployment")
-    elif is_uri_based_on_scan(pimage.imageUri):
-        ScannedInstanceId = extract_scannedinstance_id(pimage.imageUri)
-        ScanId = extract_scan_id(pimage.imageUri)
-        source = image_object.api.Users(image_object.login).Scannedinstances(ScannedInstanceId).Scans(ScanId).Get()
+            raise TypeError("No template found for this image")
+        else:
+            return imageObject.api.Users(imageObject.login).Appliances(source.dbId).Images(imageId).Pimages(
+                publishImage.dbId).Deploys.Deploy(body=deployment, element_name="ns1:deployment")
+
+    elif is_uri_based_on_scan(publishImage.imageUri):
+        scannedInstanceId = extract_scannedinstance_id(publishImage.imageUri)
+        scanId = extract_scan_id(publishImage.imageUri)
+        source = imageObject.api.Users(imageObject.login).Scannedinstances(scannedInstanceId).Scans(scanId).Get()
+
         if source is None or not hasattr(source, 'dbId'):
-            printer.out("No scan found for this image", printer.ERROR)
-            return 2
-        deployed_instance = image_object.api.Users(image_object.login).Scannedinstances(ScannedInstanceId).Scans(
-            ScanId).Images(Itid=image_id).Pimages(pimage.dbId).Deploys.Deploy(body=deployment, element_name="ns1:deployment")
+            raise TypeError("No scan found for this image")
+        else:
+            return imageObject.api.Users(imageObject.login).Scannedinstances(scannedInstanceId).Scans(
+                scanId).Images(Itid=imageId).Pimages(publishImage.dbId).Deploys.Deploy(body=deployment,
+                                                                                       element_name="ns1:deployment")
     else:
-        printer.out("No source found for this image", printer.ERROR)
-        return 2
-    return deployed_instance
+        raise TypeError("No source found for this image")
+
 
 def print_deploy_info(image_object, status, deployed_instance_id):
     if status.message == "on-fire":
@@ -272,6 +291,8 @@ def print_deploy_info(image_object, status, deployed_instance_id):
         return 0
 
 def show_deploy_progress_without_percentage(image_object, deployed_instance_id):
+    printer.out("Deployment in progress", printer.INFO)
+
     status = image_object.api.Users(image_object.login).Deployments(deployed_instance_id).Status.Getdeploystatus()
     bar = ProgressBar(widgets=[BouncingBar()], maxval=UnknownLength)
     bar.start()

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -86,7 +86,7 @@ def check_and_get_attributes_from_file(deploy_file, expected_attributes):
     return file_attributes
 
 
-def build_deployment_amazon(attributes):
+def build_deployment_aws(attributes):
     deployment = Deployment()
     myInstance = InstanceAmazon()
 

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -77,13 +77,13 @@ def validate_deployment(file):
         printer.out("unknown error deployment json file", printer.ERROR)
 
 
-def check_and_get_attributes_from_file(file, expectedAttributes):
-    attributes = validate_deployment(file)
-    for attribute in expectedAttributes:
-        if not attribute in attributes:
-            raise TypeError("There is no attribute [" + attribute + "] for the provisioner")
+def check_and_get_attributes_from_file(deploy_file, expected_attributes):
+    file_attributes = validate_deployment(deploy_file)
+    for attribute in expected_attributes:
+        if not attribute in file_attributes:
+            raise ValueError("There is no attribute [" + attribute + "] for the provisioner")
 
-    return attributes
+    return file_attributes
 
 
 def build_deployment_amazon(attributes):
@@ -228,7 +228,9 @@ def create_progress_bar_openstack(bar_status):
     return progress
 
 
-def call_deploy(imageObject, publishImage, deployment, imageId):
+def call_deploy(imageObject, publishImage, deployment):
+    image_id = generics_utils.extract_id(publishImage.imageUri)
+
     if is_uri_based_on_appliance(publishImage.imageUri):
         source = imageObject.api.Users(imageObject.login).Appliances(
             generics_utils.extract_id(publishImage.applianceUri)).Get()

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -91,14 +91,7 @@ def build_deployment_amazon(attributes):
     myInstance = InstanceAmazon()
 
     deployment.name = attributes["name"]
-    if not "cores" in attributes:
-        myInstance.cores = "1"
-    else:
-        myInstance.cores = attributes["cores"]
-    if not "memory" in attributes:
-        myInstance.memory = "1024"
-    else:
-        myInstance.memory = attributes["memory"]
+    get_instance_cores_and_memory(myInstance, attributes)
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
@@ -120,19 +113,23 @@ def build_deployment_azure(attributes):
     else:
         myInstance.userPassword = query_password_azure("Please enter the password to connect to the instance: ")
 
-    if not "cores" in attributes:
-        myInstance.cores = "1"
-    else:
-        myInstance.cores = attributes["cores"]
-    if not "memory" in attributes:
-        myInstance.memory = "1024"
-    else:
-        myInstance.memory = attributes["memory"]
+    get_instance_cores_and_memory(myInstance, attributes)
 
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
     deployment.instances.append(myInstance)
     return deployment
+
+
+def get_instance_cores_and_memory(my_instance, attributes):
+    if not "cores" in attributes:
+        my_instance.cores = "1"
+    else:
+        my_instance.cores = attributes["cores"]
+    if not "memory" in attributes:
+        my_instance.memory = "1024"
+    else:
+        my_instance.memory = attributes["memory"]
 
 
 def build_deployment_openstack(attributes, publishImage, credAccountRessources):

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -93,9 +93,7 @@ def build_deployment_aws(attributes):
     deployment.name = attributes["name"]
     set_instance_cores_and_memory(my_instance, attributes)
 
-    deployment.instances = pyxb.BIND()
-    deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(my_instance)
+    append_instance_to_deployment(deployment, my_instance)
     return deployment
 
 
@@ -115,9 +113,7 @@ def build_deployment_azure(attributes):
 
     set_instance_cores_and_memory(my_instance, attributes)
 
-    deployment.instances = pyxb.BIND()
-    deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
-    deployment.instances.append(my_instance)
+    append_instance_to_deployment(deployment, my_instance)
     return deployment
 
 
@@ -144,10 +140,14 @@ def build_deployment_openstack(attributes, publish_image, cred_account_ressource
     my_instance.networkId, my_instance.flavorId = retrieve_openstack_resources(my_instance.region, network_name,
                                                                              flavor_name, publish_image, cred_account_ressources)
 
+    append_instance_to_deployment(deployment, my_instance)
+    return deployment
+
+
+def append_instance_to_deployment(deployment, my_instance):
     deployment.instances = pyxb.BIND()
     deployment.instances._ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Instances')
     deployment.instances.append(my_instance)
-    return deployment
 
 
 def retrieve_openstack_resources(regionName, networkName, flavorName, publishImage, credAccountRessources):

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -79,6 +79,10 @@ def validate_deployment(file):
 
 def check_and_get_attributes_from_file(deploy_file, expected_attributes):
     file_attributes = validate_deployment(deploy_file)
+
+    if expected_attributes is None:
+        return file_attributes
+
     for attribute in expected_attributes:
         if not attribute in file_attributes:
             raise ValueError("There is no attribute [" + attribute + "] for the provisioner")

--- a/tests/unit/commands/image/test_deploy_azure.py
+++ b/tests/unit/commands/image/test_deploy_azure.py
@@ -136,7 +136,7 @@ class TestDeployAzure(TestCase):
         newImage.status = "complete"
         newImage.status.complete = True
         newImage.targetFormat = uforge.targetFormat()
-        newImage.targetFormat.name = "Azure ARM"
+        newImage.targetFormat.name = "Microsoft Azure"
 
         new_pimages.publishImages.append(newImage)
 
@@ -152,7 +152,7 @@ class TestDeployAzure(TestCase):
         newImage.status = "complete"
         newImage.status.complete = True
         newImage.targetFormat = uforge.targetFormat()
-        newImage.targetFormat.name = "Azure ARM"
+        newImage.targetFormat.name = "Microsoft Azure"
 
         new_pimages.publishImages.append(newImage)
 

--- a/tests/unit/utils/test_deploy_utils.py
+++ b/tests/unit/utils/test_deploy_utils.py
@@ -43,7 +43,7 @@ class TestDeployUtils(TestCase):
         file = findRelativePathFor("tests/integration/data/deploy_aws_incomplete.yml")
 
         # When
-        return_value = build_deployment_amazon(file)
+        return_value = build_deployment_aws(file)
 
         #Then
         self.assertEquals(return_value, None)

--- a/tests/unit/utils/test_deploy_utils.py
+++ b/tests/unit/utils/test_deploy_utils.py
@@ -33,27 +33,36 @@ class TestDeployUtils(TestCase):
         file = findRelativePathFor("tests/integration/data/deploy_openstack_incomplete.yml")
 
         # When
-        return_value = build_deployment_openstack(file, None, None, None)
+        try:
+            check_and_get_attributes_from_file(file, ["name", "region", "network", "flavor"])
+        except ValueError:
+            return
 
         #Then
-        self.assertEquals(return_value, None)
+        self.fail(self)
 
     def testbuild_deployment_amazon_returns_None_when_file_incomplete(self):
         # Given
         file = findRelativePathFor("tests/integration/data/deploy_aws_incomplete.yml")
 
         # When
-        return_value = build_deployment_aws(file)
+        try:
+            check_and_get_attributes_from_file(file, ["name"])
+        except ValueError:
+            return
 
         #Then
-        self.assertEquals(return_value, None)
+        self.fail(self)
 
     def testbuild_deployment_azure_returns_None_when_file_incomplete(self):
         # Given
         file = findRelativePathFor("tests/integration/data/deploy_azure_incomplete.yml")
 
         # When
-        return_value = build_deployment_azure(file)
+        try:
+            check_and_get_attributes_from_file(file, ["name", "userName"])
+        except ValueError:
+            return
 
         #Then
-        self.assertEquals(return_value, None)
+        self.fail(self)


### PR DESCRIPTION
- Cleaned code
- Created generic method to check deploy files attributes
- For OpenStack: now check file before trying to retrieve informations
- Now display a clean error if network name or flavor name do not exist on OpenStack (issues/289)
- Refactored retrieve_openstack_resources and call_deploy methods
- Now use TypeError exceptions instead of return None in case something goes wrong
	- If an attribute is not found during OpenStack retrieval, now throw a TypeError exception instead of a None value.
	- TypeError exceptions are now catched in main do_deploy method, and return a code 2
- Remove an exception handling so that it is handled at the top