### PR TITLE
Documentation Fix

### DIFF
--- a/documentation/en/source/pages/getting-started/build-machine-image.rst
+++ b/documentation/en/source/pages/getting-started/build-machine-image.rst
@@ -78,7 +78,7 @@ Lets now use this account to build a machine image for Amazon EC2. Open up the f
     installation:
       diskSize: 10240
     region: eu-west-1
-    s3bucket: mybucketname
+    bucket: mybucketname
 
 If you are using JSON (file ``nginx-template.json``):
 
@@ -113,7 +113,7 @@ If you are using JSON (file ``nginx-template.json``):
           "diskSize": 10240
         },
         "region": "eu-west-1",
-        "s3bucket": "mybucketname"
+        "bucket": "mybucketname"
       }
     ]
   }

--- a/documentation/en/source/pages/getting-started/build-machine-image.rst
+++ b/documentation/en/source/pages/getting-started/build-machine-image.rst
@@ -15,7 +15,7 @@ For security reasons, it is recommended not to add any cloud account information
 
   ---
   accounts:
-  - type: Amazon
+  - type: Amazon AWS
     name: James AWS Account
     accountNumber: 11111-111111-1111
     accessKeyId: myaccessKeyid
@@ -30,7 +30,7 @@ If you are using JSON:
   {
     "accounts": [
       {
-        "type": "Amazon",
+        "type": "Amazon AWS",
         "name": "James AWS Account",
         "accountNumber": "11111-111111-1111",
         "accessKeyId": "myaccessKeyid",
@@ -72,7 +72,7 @@ Lets now use this account to build a machine image for Amazon EC2. Open up the f
     installation:
       diskSize: 12288
   builders:
-  - type: Amazon
+  - type: Amazon AWS
     account:
       name: James AWS Account
     installation:
@@ -105,7 +105,7 @@ If you are using JSON (file ``nginx-template.json``):
     },
     "builders": [
       {
-        "type": "Amazon",
+        "type": "Amazon AWS",
         "account": {
           "name": "James AWS Account"
         },

--- a/documentation/en/source/pages/templates-spec/builders/builders-outscale.rst
+++ b/documentation/en/source/pages/templates-spec/builders/builders-outscale.rst
@@ -176,7 +176,7 @@ If you are using YAML:
 	  installation:
 	    diskSize: 10240
 	  region: eu-west-2
-	  s3bucket: centos-template
+	  bucket: centos-template
 
 If you are using JSON:
 
@@ -193,7 +193,7 @@ If you are using JSON:
 	        "diskSize": 10240
 	      },
 	      "region": "eu-west-2",
-	      "s3bucket": "centos-template"
+	      "bucket": "centos-template"
 	    }
 	  ]
 	}
@@ -212,7 +212,7 @@ If you are using YAML:
 	  installation:
 	    diskSize: 10240
 	  region: eu-west-2
-	  s3bucket: centos-template
+	  bucket: centos-template
 
 If you are using JSON:
 
@@ -229,7 +229,7 @@ If you are using JSON:
 	        "diskSize": 10240
 	      },
 	      "region": "eu-west-2",
-	      "s3bucket": "centos-template"
+	      "bucket": "centos-template"
 	    }
 	  ]
 	}


### PR DESCRIPTION
Hello,

Thanks to the french event "La nuit de l'info" wich took place on Wednesday 06 December 2017, i've got the opportunity to discover this project.
My group doesn't deliver anything but we have discovered some mistakes on the documentation and bugs which retarded our rush.

- An exception is risen when Amazon builder type is "Amazon" and not "Amazon AWS". The annotation's correction seems to be forgotten. (please see my commit)
- Idem for s3bucket which seems to be renamed from s3bucket to bucket (commit)
- An exception is risen when providing an integer Amazon Customer client (accountNumber) id in JSON format. (As my Amazon account number doesn't contain any '-' we make the mistake to forget to provide a int instead a string.

Notices about the event:
- We noticed a lake of documentation with Docker's platform on the documentation site.
I've found a blog article that provide an example but redirects to a 404 page.
Article page: https://blog.usharesoft.com/index.php?article71/how-to-build-docker-base-images
404 link: https://www.usharesoft.com/resources/downloads/docker-centos7-built-with-uforge.tar.gz
Unfortunately, I've only notice today the link is available here (https://www.usharesoft.com/wp-content/uploads/2017/10/docker-centos7-built-with-uforge.tar.gz).
- Lastly, the free account only allowed us to generate 5 VMs which wasn't enough to test UForge.

`hammr -v`
hammr version '3.7.8'
`


