### PR TITLE
Use parentUri in image instead of applianceUri

### DIFF
--- a/hammr/commands/template/template.py
+++ b/hammr/commands/template/template.py
@@ -68,7 +68,7 @@ class Template(Cmd, CoreGlobal):
                     nbImage=0
                     if images is not None and hasattr(images, 'image'):
                         for image in images.image:
-                            if hasattr(image, 'applianceUri') and image.applianceUri == appliance.uri:
+                            if hasattr(image, 'parentUri') and image.parentUri == appliance.uri:
                                 nbImage+=1
                     table.add_row([appliance.dbId, appliance.name, str(appliance.version), appliance.distributionName+" "+appliance.archName,
                                    appliance.created.strftime("%Y-%m-%d %H:%M:%S"), appliance.lastModified.strftime("%Y-%m-%d %H:%M:%S"), nbImage, appliance.nbUpdates, "X" if appliance.imported else "", "X" if appliance.shared else ""])

--- a/hammr/utils/deployment_utils.py
+++ b/hammr/utils/deployment_utils.py
@@ -41,7 +41,7 @@ def retrieve_credaccount(image_object, pimageId, pimage):
 
 def retrieve_credaccount_from_app(image_object, pimageId, pimage):
     image_id = generics_utils.extract_id(pimage.imageUri)
-    source_id = generics_utils.extract_id(pimage.applianceUri)
+    source_id = generics_utils.extract_id(pimage.parentUri)
     account_id = pimage.credAccount.dbId
     return image_object.api.Users(image_object.login).Appliances(source_id).Images(image_id).Pimages(pimageId).\
         Accounts(account_id).Resources.Getaccountresources()
@@ -214,7 +214,7 @@ def call_deploy(image_object, publish_image, deployment):
 
     if is_uri_based_on_appliance(publish_image.imageUri):
         source = image_object.api.Users(image_object.login).Appliances(
-            generics_utils.extract_id(publish_image.applianceUri)).Get()
+            generics_utils.extract_id(publish_image.parentUri)).Get()
 
         if source is None or not hasattr(source, 'dbId'):
             raise TypeError("No template found for this image")

--- a/hammr/utils/publish_utils.py
+++ b/hammr/utils/publish_utils.py
@@ -26,7 +26,7 @@ from ussclicore.utils import generics_utils, printer, progressbar_widget, downlo
 def retrieve_source_from_image(image_object, image):
     if is_uri_based_on_appliance(image.uri):
         source = image_object.api.Users(image_object.login).Appliances(
-            generics_utils.extract_id(image.applianceUri)).Get()
+            generics_utils.extract_id(image.parentUri)).Get()
 
     elif is_uri_based_on_scan(image.uri):
         scanned_instance_id = extract_scannedinstance_id(image.uri)
@@ -215,7 +215,7 @@ def publish_image_from_builder(image_object, builder, template, source, counter,
 
         publish_image = image_object.retrieve_publish_image_with_target_format_builder(image, builder)
         publish_image.imageUri = image.uri
-        publish_image.applianceUri = source.uri
+        publish_image.parentUri = source.uri
         publish_image.credAccount = get_account_to_publish(image_object, builder)
         account_name = publish_image.credAccount.name
 

--- a/tests/unit/commands/image/test_deploy_aws.py
+++ b/tests/unit/commands/image/test_deploy_aws.py
@@ -146,7 +146,7 @@ class TestDeployAWS(TestCase):
         publish_image = PublishImageAws()
         publish_image.dbId = 1234
         publish_image.imageUri = 'users/guest/appliances/5/images/1234'
-        publish_image.applianceUri = 'users/guest/appliances/5'
+        publish_image.parentUri = 'users/guest/appliances/5'
         publish_image.status = "complete"
         publish_image.status.complete = True
         publish_image.targetFormat = uforge.targetFormat()

--- a/tests/unit/commands/image/test_deploy_azure.py
+++ b/tests/unit/commands/image/test_deploy_azure.py
@@ -132,7 +132,7 @@ class TestDeployAzure(TestCase):
         publish_image = PublishImageAzure()
         publish_image.dbId = 1234
         publish_image.imageUri = 'users/guest/appliances/5/images/1234'
-        publish_image.applianceUri = 'users/guest/appliances/5'
+        publish_image.parentUri = 'users/guest/appliances/5'
         publish_image.status = "complete"
         publish_image.status.complete = True
         publish_image.targetFormat = uforge.targetFormat()

--- a/tests/unit/commands/image/test_deploy_openstack.py
+++ b/tests/unit/commands/image/test_deploy_openstack.py
@@ -158,7 +158,7 @@ class TestDeployOpenStack(TestCase):
         publish_image = PublishImageOpenStack()
         publish_image.dbId = 1234
         publish_image.imageUri = 'users/guest/appliances/5/images/116'
-        publish_image.applianceUri = 'users/guest/appliances/5'
+        publish_image.parentUri = 'users/guest/appliances/5'
         publish_image.status = "complete"
         publish_image.status.complete = True
         publish_image.targetFormat = uforge.targetFormat()


### PR DESCRIPTION
-  For Image, applianceUri has been renamed to parentUri in sdk because it represent the uri resource of the parent object the machine image was generated from.