### PR TITLE
Fix issue #224

### DIFF
--- a/hammr/commands/template/template.py
+++ b/hammr/commands/template/template.py
@@ -359,24 +359,24 @@ class Template(Cmd, CoreGlobal):
 
 
     def arg_build(self):
-        doParser = ArgumentParser(prog=self.cmd_name+" build", add_help = True, description="Builds a machine image from the template")
-        mandatory = doParser.add_argument_group("mandatory arguments")
+        do_parser = ArgumentParser(prog=self.cmd_name+" build", add_help = True, description="Builds a machine image from the template")
+        mandatory = do_parser.add_argument_group("mandatory arguments")
         mandatory.add_argument('--file', dest='file', required=True, help="yaml/json file providing the builder parameters")
-        optional = doParser.add_argument_group("optional arguments")
+        optional = do_parser.add_argument_group("optional arguments")
         optional.add_argument('--id',dest='id',required=False, help="id of the template to build")
         optional.add_argument('--junit',dest='junit',required=False, help="name of junit XML output file")
         optional.add_argument('--simulate', dest='simulated', action='store_true', help='Simulate the generation (only the Checking Dependencies process will be executed)', required = False)
         optional.add_argument('--force', dest='forced', action='store_true', help='Force the checking dependencies', required = False)
-        return doParser
+        return do_parser
 
     def do_build(self, args):
         try:
             #add arguments
-            doParser = self.arg_build()
-            doArgs = doParser.parse_args(shlex.split(args))
+            do_parser = self.arg_build()
+            do_args = do_parser.parse_args(shlex.split(args))
 
             #if the help command is called, parse_args returns None object
-            if not doArgs:
+            if not do_args:
                     return 2
 
             if do_args.id:
@@ -387,19 +387,19 @@ class Template(Cmd, CoreGlobal):
             if template is None:
                 return 2
 
-            if doArgs.id:
-                myAppliance = self.api.Users(self.login).Appliances().Getall(Query="dbId=="+doArgs.id)
-                myAppliance = myAppliance.appliances.appliance
+            if do_args.id:
+                my_appliance = self.api.Users(self.login).Appliances().Getall(Query="dbId=="+do_args.id)
+                my_appliance = my_appliance.appliances.appliance
             else:
                 #Get template which correpond to the template file
-                myAppliance = self.api.Users(self.login).Appliances().Getall(Query="name=='"+template["stack"]["name"]+"';version=='"+template["stack"]["version"]+"'")
-                myAppliance = myAppliance.appliances.appliance
-            if myAppliance is None or len(myAppliance)!=1:
+                my_appliance = self.api.Users(self.login).Appliances().Getall(Query="name=='"+template["stack"]["name"]+"';version=='"+template["stack"]["version"]+"'")
+                my_appliance = my_appliance.appliances.appliance
+            if my_appliance is None or len(my_appliance)!=1:
                 printer.out("No template found on the plateform")
                 return 0
-            myAppliance=myAppliance[0]
-            rInstallProfile = self.api.Users(self.login).Appliances(myAppliance.dbId).Installprofile("").Getdeprecated()
-            if rInstallProfile is None:
+            my_appliance=my_appliance[0]
+            r_install_profile = self.api.Users(self.login).Appliances(my_appliance.dbId).Installprofile("").Getdeprecated()
+            if r_install_profile is None:
                 printer.out("No installation found on the template '"+template["stack"]["name"]+"'", printer.ERROR)
                 return 0
             try:
@@ -416,26 +416,26 @@ class Template(Cmd, CoreGlobal):
                         start_time = time.time()
 
                         format_type = builder["type"]
-                        targetFormat = generate_utils.get_target_format_object(self.api, self.login, format_type)
-                        if targetFormat is None:
+                        target_format = generate_utils.get_target_format_object(self.api, self.login, format_type)
+                        if target_format is None:
                             printer.out("Builder type unknown: "+format_type, printer.ERROR)
                             return 2
 
                         myimage = image()
-                        myinstallProfile = installProfile()
-                        if rInstallProfile.partitionAuto:
+                        myinstall_profile = installProfile()
+                        if r_install_profile.partitionAuto:
                             if "installation" in builder:
                                 if "swapSize" in builder["installation"]:
-                                    myinstallProfile.swapSize = builder["installation"]["swapSize"]
+                                    myinstall_profile.swapSize = builder["installation"]["swapSize"]
                                 if "diskSize" in builder["installation"]:
-                                    myinstallProfile.diskSize = builder["installation"]["diskSize"]
+                                    myinstall_profile.diskSize = builder["installation"]["diskSize"]
                             else:
-                                myinstallProfile.swapSize = rInstallProfile.swapSize
-                                myinstallProfile.diskSize = rInstallProfile.partitionTable.disks.disk[0].size
+                                myinstall_profile.swapSize = r_install_profile.swapSize
+                                myinstall_profile.diskSize = r_install_profile.partitionTable.disks.disk[0].size
 
-                        func = getattr(generate_utils, "generate_"+generics_utils.remove_special_chars(targetFormat.format.name), None)
+                        func = getattr(generate_utils, "generate_"+generics_utils.remove_special_chars(target_format.format.name), None)
                         if func:
-                            myimage,myinstallProfile = func(myimage, builder, myinstallProfile, self.api, self.login)
+                            myimage,myinstall_profile = func(myimage, builder, myinstall_profile, self.api, self.login)
                         else:
                             printer.out("Builder type unknown: "+format_type, printer.ERROR)
                             return 2
@@ -444,62 +444,62 @@ class Template(Cmd, CoreGlobal):
                         if myimage is None:
                             return 2
 
-                        myimage.targetFormat = targetFormat
-                        myimage.installProfile = myinstallProfile
-                        if doArgs.simulated is not None and doArgs.simulated:
+                        myimage.targetFormat = target_format
+                        myimage.installProfile = myinstall_profile
+                        if do_args.simulated is not None and do_args.simulated:
                             myimage.simulated=True
-                        if doArgs.forced is not None and doArgs.forced:
+                        if do_args.forced is not None and do_args.forced:
                             myimage.forceCheckingDeps=True
 
-                        rImage = self.api.Users(self.login).Appliances(myAppliance.dbId).Images().Generate(myimage)
+                        r_image = self.api.Users(self.login).Appliances(my_appliance.dbId).Images().Generate(myimage)
 
-                        status = rImage.status
-                        statusWidget = progressbar_widget.Status()
-                        statusWidget.status = status
-                        widgets = [Bar('>'), ' ', statusWidget, ' ', ReverseBar('<')]
+                        status = r_image.status
+                        status_widget = progressbar_widget.Status()
+                        status_widget.status = status
+                        widgets = [Bar('>'), ' ', status_widget, ' ', ReverseBar('<')]
                         progress = ProgressBar(widgets=widgets, maxval=100).start()
                         while not (status.complete or status.error or status.cancelled):
-                            statusWidget.status = status
+                            status_widget.status = status
                             progress.update(status.percentage)
-                            status = self.api.Users(self.login).Appliances(myAppliance.dbId).Images(rImage.dbId).Status.Get()
+                            status = self.api.Users(self.login).Appliances(my_appliance.dbId).Images(r_image.dbId).Status.Get()
                             time.sleep(2)
-                        statusWidget.status = status
+                        status_widget.status = status
                         progress.finish()
                         if status.error:
                             printer.out("Generation '"+builder["type"]+"' error: "+status.message+"\n"+status.errorMessage, printer.ERROR)
                             if status.detailedError:
                                 printer.out(status.detailedErrorMsg)
-                            if doArgs.junit is not None:
+                            if do_args.junit is not None:
                                 test.elapsed_sec=time.time() - start_time
                                 test.add_error_info("Error", status.message+"\n"+status.errorMessage)
                         elif status.cancelled:
                             printer.out("Generation '"+builder["type"]+"' canceled: "+status.message, printer.WARNING)
-                            if doArgs.junit is not None:
+                            if do_args.junit is not None:
                                 test.elapsed_sec=time.time() - start_time
                                 test.add_failure_info("Canceled", status.message)
                         else:
                             printer.out("Generation '"+builder["type"]+"' ok", printer.OK)
-                            printer.out("Image URI: "+rImage.uri)
-                            printer.out("Image Id : "+generics_utils.extract_id(rImage.uri))
-                            if doArgs.junit is not None:
+                            printer.out("Image URI: "+r_image.uri)
+                            printer.out("Image Id : "+generics_utils.extract_id(r_image.uri))
+                            if do_args.junit is not None:
                                 test.elapsed_sec=time.time() - start_time
                                 #the downloadUri already contains downloadKey at the end
-                                if rImage.downloadUri is not None:
-                                    test.stdout=self.api.getUrl() +"/"+rImage.downloadUri
+                                if r_image.downloadUri is not None:
+                                    test.stdout=self.api.getUrl() +"/"+r_image.downloadUri
                         i+=1
                     except Exception as e:
                         if  is_uforge_exception(e):
                             print_uforge_exception(e)
-                            if doArgs.junit is not None and "test_results" in locals() and len(test_results)>0:
+                            if do_args.junit is not None and "test_results" in locals() and len(test_results)>0:
                                 test=test_results[len(test_results)-1]
                                 test.elapsed_sec=time.time() - start_time
                                 test.add_error_info("Error", get_uforge_exception(e))
                         else:
                             raise
-                if doArgs.junit is not None:
-                    testName = myAppliance.distributionName+" "+myAppliance.archName
-                    ts = TestSuite("Generation "+testName, test_results)
-                    with open(doArgs.junit, 'w') as f:
+                if do_args.junit is not None:
+                    test_name = my_appliance.distributionName+" "+my_appliance.archName
+                    ts = TestSuite("Generation "+test_name, test_results)
+                    with open(do_args.junit, 'w') as f:
                         TestSuite.to_file(f, [ts], prettyprint=False)
                 return 0
             except KeyError as e:
@@ -511,15 +511,15 @@ class Template(Cmd, CoreGlobal):
         except KeyboardInterrupt:
             printer.out("\n")
             if generics_utils.query_yes_no("Do you want to cancel the job ?"):
-                if 'myAppliance' in locals() and 'rImage' in locals() and hasattr(myAppliance, 'dbId') and hasattr(rImage, 'dbId'):
-                    self.api.Users(self.login).Appliances(myAppliance.dbId).Images(rImage.dbId).Status.Cancel()
+                if 'my_appliance' in locals() and 'rImage' in locals() and hasattr(my_appliance, 'dbId') and hasattr(r_image, 'dbId'):
+                    self.api.Users(self.login).Appliances(my_appliance.dbId).Images(r_image.dbId).Status.Cancel()
                 else:
                     printer.out("Impossible to cancel", printer.WARNING)
             else:
                 printer.out("Exiting command")
         except Exception as e:
             print_uforge_exception(e)
-            if doArgs.junit is not None and "test_results" in locals() and len(test_results)>0:
+            if do_args.junit is not None and "test_results" in locals() and len(test_results)>0:
                 test=test_results[len(test_results)-1]
                 if "start_time" in locals():
                     elapse=time.time() - start_time
@@ -530,19 +530,19 @@ class Template(Cmd, CoreGlobal):
             else:
                 return 2
         finally:
-            if "doArgs" in locals() and doArgs.junit is not None and "test_results" in locals() and len(test_results)>0:
-                if "myAppliance" in locals():
-                    testName = myAppliance.distributionName+" "+myAppliance.archName
+            if "do_args" in locals() and do_args.junit is not None and "test_results" in locals() and len(test_results)>0:
+                if "my_appliance" in locals():
+                    test_name = my_appliance.distributionName+" "+my_appliance.archName
                 else:
-                    testName = ""
-                ts = TestSuite("Generation "+testName, test_results)
-                with open(doArgs.junit, 'w') as f:
+                    test_name = ""
+                ts = TestSuite("Generation "+test_name, test_results)
+                with open(do_args.junit, 'w') as f:
                     TestSuite.to_file(f, [ts], prettyprint=False)
 
 
     def help_build(self):
-        doParser = self.arg_build()
-        doParser.print_help()
+        do_parser = self.arg_build()
+        do_parser.print_help()
 
 
 

--- a/hammr/commands/template/template.py
+++ b/hammr/commands/template/template.py
@@ -379,8 +379,10 @@ class Template(Cmd, CoreGlobal):
             if not do_args:
                     return 2
 
-            #--
-            template=validate_structure_template(do_args.file)
+            if do_args.id:
+                template = validate(do_args.file)
+            else :
+                template=validate_builder_file_with_no_template_id(do_args.file)
             if template is None:
                 return 2
 
@@ -401,15 +403,15 @@ class Template(Cmd, CoreGlobal):
                 return 0
             try:
                 i=1
-                if do_args.junit is not None:
-                    test_results=[]
+                test_results=[]
                 for builder in template["builders"]:
                     try:
                         printer.out("Generating '"+builder["type"]+"' image ("+str(i)+"/"+str(len(template["builders"]))+")")
+                        test = None
                         if do_args.junit is not None:
                             test = TestCase('Generation '+builder["type"])
                             test_results.append(test)
-                            start_time = time.time()
+                        start_time = time.time()
 
                         format_type = builder["type"]
                         target_format = generate_utils.get_target_format_object(self.api, self.login, format_type)

--- a/hammr/utils/hammr_utils.py
+++ b/hammr/utils/hammr_utils.py
@@ -157,7 +157,7 @@ def validate_configurations_file(file, isJson):
         check_mandatory_builders(data["builders"])
     return data
 
-def validate_structure_template(file_path):
+def validate_builder_file_with_no_template_id(file_path):
     data = validate(file_path)
     if data is None:
         return None

--- a/tests/unit/commands/image/test_deploy_aws.py
+++ b/tests/unit/commands/image/test_deploy_aws.py
@@ -22,7 +22,7 @@ from hammr.utils import constants
 from uforge.objects.uforge import *
 from uforge.objects import uforge
 from tests.unit.commands.image.deploy_test_utils import prepare_image, prepare_mock_deploy
-from tests.unit.utils.file_utils import findRelativePathFor
+from tests.unit.utils.file_utils import find_relative_path_for
 
 
 class TestDeployAWS(TestCase):
@@ -136,7 +136,7 @@ class TestDeployAWS(TestCase):
         return deployment
 
     def prepare_image_deploy_command_aws(self, id):
-         args = "--file %s --publish-id %s" % (findRelativePathFor("tests/integration/data/deploy_aws.yml"), id)
+         args = "--file %s --publish-id %s" % (find_relative_path_for("tests/integration/data/deploy_aws.yml"), id)
          return args
 
     def prepare_aws_pimages_from_app(self):

--- a/tests/unit/commands/image/test_deploy_azure.py
+++ b/tests/unit/commands/image/test_deploy_azure.py
@@ -22,7 +22,7 @@ from hammr.utils import constants
 from uforge.objects.uforge import *
 from uforge.objects import uforge
 from tests.unit.commands.image.deploy_test_utils import prepare_image, prepare_mock_deploy
-from tests.unit.utils.file_utils import findRelativePathFor
+from tests.unit.utils.file_utils import find_relative_path_for
 
 
 class TestDeployAzure(TestCase):
@@ -122,7 +122,7 @@ class TestDeployAzure(TestCase):
         return deployment
 
     def prepare_image_deploy_command_azure(self, id):
-         args = "--file %s --publish-id %s" % (findRelativePathFor("tests/integration/data/deploy_azure.yml"), id)
+         args = "--file %s --publish-id %s" % (find_relative_path_for("tests/integration/data/deploy_azure.yml"), id)
          return args
 
     def prepare_azure_pimages_from_app(self):

--- a/tests/unit/commands/image/test_deploy_openstack.py
+++ b/tests/unit/commands/image/test_deploy_openstack.py
@@ -22,7 +22,7 @@ from hammr.utils import constants
 from uforge.objects.uforge import *
 from uforge.objects import uforge
 from tests.unit.commands.image.deploy_test_utils import prepare_image, prepare_mock_deploy
-from tests.unit.utils.file_utils import findRelativePathFor
+from tests.unit.utils.file_utils import find_relative_path_for
 from tests.unit.utils.pyxb_utils import get_pyXB_anon_type_for_list_attrb, get_pyXB_anon_type_for_simple_attrb
 
 
@@ -136,7 +136,7 @@ class TestDeployOpenStack(TestCase):
         return deployment
 
     def prepare_image_deploy_command_openstack(self, id):
-         args = "--file %s --publish-id %s" % (findRelativePathFor("tests/integration/data/deploy_openstack.yml"), id)
+         args = "--file %s --publish-id %s" % (find_relative_path_for("tests/integration/data/deploy_openstack.yml"), id)
          return args
 
     def prepare_openstack_credaccount(self):

--- a/tests/unit/commands/template/test_template.py
+++ b/tests/unit/commands/template/test_template.py
@@ -25,31 +25,31 @@ from mock import ANY
 from hammr.utils import constants
 import datetime
 
+from tests.unit.utils.file_utils import find_relative_path_for
+
 
 class TestTemplate(TestCase):
     def test_do_clone_should_split_parameters_even_with_spaces(self):
         # given
-        t = template.Template()
+        template = self.create_template("url", "username", "password", "login", "password")
         name = "my new name wit spaces"
         args = "--id 42 --name '%s' --version 1.0" % name
-        t.clone_appliance = MagicMock(return_value=appliance())
+        template.clone_appliance = MagicMock(return_value=appliance())
 
         # when
-        t.do_clone(args)
+        template.do_clone(args)
 
         # then
-        self.assertEqual(t.clone_appliance.call_count, 1)
-        self.assertEqual(t.clone_appliance.call_args[0][1].name, name)
+        self.assertEqual(template.clone_appliance.call_count, 1)
+        self.assertEqual(template.clone_appliance.call_args[0][1].name, name)
 
     @patch('uforge.application.Api._Users._Appliances.Getall')
     @patch('uforge.application.Api._Users._Images.Getall')
     @patch('texttable.Texttable.add_row')
     def test_do_list_succeed_when_appliance_list_with_UTC_Timezone(self, mock_table_add_row, mock_api_images_getall,mock_api_appliance_getall):
         # given
-        t = template.Template()
-        t.api = Api("url", username="username", password="password", headers=None, disable_ssl_certificate_validation = False, timeout = constants.HTTP_TIMEOUT)
-        t.login = "login"
-        t.password = "password"
+        template = self.create_template("url", "username", "password", "login", "password")
+
         timeZone = "UTC"
         self.create_appliance_list(timeZone, mock_api_appliance_getall)
         new_images = Images()
@@ -57,12 +57,56 @@ class TestTemplate(TestCase):
         mock_api_images_getall.return_value = new_images
 
         # when
-        t.do_list("")
+        template.do_list("")
 
         # then
         self.assertEquals(mock_table_add_row.call_count, 1)
         mock_table_add_row.assert_called_with([1, "ApplianceWithInstallProfileUTCTimezone", "1.0", "Ubuntu 14.x x86_64", ANY, ANY, 0, None, ANY, ANY])
 
+    def test_do_build_should_return_2_when_no_id_given_and_no_stack_section(self):
+        # given
+        yaml_path = find_relative_path_for("tests/integration/data/publish_builder.yml")
+        args = "--file '%s'" % yaml_path
+
+        template = self.create_template("url", "username", "password", "login", "password")
+
+        # when
+        return_value = template.do_build(args)
+
+        # then
+        self.assertEqual(2, return_value)
+
+    @patch('uforge.application.Api._Users._Appliances._Images.Generate')
+    @patch('uforge.application.Api._Users._Targetformats.Getall')
+    @patch('uforge.application.Api._Users._Appliances._Installprofile.Getdeprecated')
+    @patch('uforge.application.Api._Users._Appliances.Getall')
+    def test_do_build_should_return_0_when_id_given_and_no_stack_section(self, mock_api_appliance_getall,
+                                                                         mock_api_appliance_getinstallprofile, mock_api_targetformat_getall, mock_api_generate):
+        # given
+        yaml_path = find_relative_path_for("tests/integration/data/publish_builder.yml")
+        args = "--file '%s' --id 1" % yaml_path
+
+        template = self.create_template("url", "username", "password", "login", "password")
+        timeZone = "UTC"
+
+        self.create_appliance_list(timeZone, mock_api_appliance_getall)
+        self.create_installprofile(timeZone, mock_api_appliance_getinstallprofile)
+        self.create_targetformat_list(mock_api_targetformat_getall)
+        self.create_targetformat_list(mock_api_targetformat_getall)
+        self.prepare_mock_generate(mock_api_generate)
+
+        # when
+        return_value = template.do_build(args)
+
+        # then
+        self.assertEqual(0, return_value)
+
+    def create_template(self, url, username, password, template_login, template_password):
+        templ = template.Template()
+        templ.api = Api(url, username=username, password=password, headers=None, disable_ssl_certificate_validation = False, timeout = constants.HTTP_TIMEOUT)
+        templ.login = template_login
+        templ.password = template_password
+        return templ
 
     def create_appliance_list(self, timeZone, mock_api_appliance_getall):
             new_appliances = Appliances()
@@ -84,3 +128,33 @@ class TestTemplate(TestCase):
             new_appliances.appliances.append(newAppliance)
 
             mock_api_appliance_getall.return_value = new_appliances
+
+    def create_installprofile(self, timeZone, mock_api_appliance_getinstallprofile):
+            install_profile = InstallProfile()
+            install_profile.timezone = timeZone
+
+            mock_api_appliance_getinstallprofile.return_value = install_profile
+
+    def create_targetformat_list(self, mock_api_targetformat_getall):
+            new_targetformats = TargetFormats()
+            new_targetformats.targetFormats = pyxb.BIND()
+
+            format1 = ImageFormat()
+            format1.name = "openstackqcow2"
+
+            targetformat1 = TargetFormat()
+            targetformat1.format = format1
+            targetformat1.name = "OpenStack QCOW2"
+            new_targetformats.targetFormats.append(targetformat1)
+
+            mock_api_targetformat_getall.return_value = new_targetformats
+
+
+    def prepare_mock_generate(self, mock_api_generate):
+        image = Image()
+        status = OpStatus()
+        status.complete = True
+        status.message  = "complete"
+        image.status = status
+        image.uri = "/myimages/2"
+        mock_api_generate.return_value = image

--- a/tests/unit/utils/file_utils.py
+++ b/tests/unit/utils/file_utils.py
@@ -14,11 +14,11 @@
 #    under the License.
 import os.path
 
-def findRelativePathFor(myUnitTestDataFile):
+def find_relative_path_for(my_unit_test_data_file):
     # When Unit Tests are launched from pycharm, the path is the directory of the unit test file
-    if os.path.isfile('../../../' + myUnitTestDataFile):
-        return '../../../' + myUnitTestDataFile
-    if os.path.isfile('../../../../' + myUnitTestDataFile):
-        return '../../../../' + myUnitTestDataFile
+    if os.path.isfile('../../../' + my_unit_test_data_file):
+        return '../../../' + my_unit_test_data_file
+    if os.path.isfile('../../../../' + my_unit_test_data_file):
+        return '../../../../' + my_unit_test_data_file
     # When Unit Tests are launched from CI, the path is the project directory
-    return myUnitTestDataFile
+    return my_unit_test_data_file

--- a/tests/unit/utils/test_deploy_utils.py
+++ b/tests/unit/utils/test_deploy_utils.py
@@ -23,14 +23,14 @@ from uforge.objects.uforge import *
 from uforge.objects import uforge
 import datetime
 from hammr.utils.deployment_utils import *
-from tests.unit.utils.file_utils import findRelativePathFor
+from tests.unit.utils.file_utils import find_relative_path_for
 
 
 class TestDeployUtils(TestCase):
 
     def test_build_deployment_openstack_returns_None_when_file_incomplete(self):
         # Given
-        file = findRelativePathFor("tests/integration/data/deploy_openstack_incomplete.yml")
+        file = find_relative_path_for("tests/integration/data/deploy_openstack_incomplete.yml")
 
         # When
         try:
@@ -43,7 +43,7 @@ class TestDeployUtils(TestCase):
 
     def testbuild_deployment_amazon_returns_None_when_file_incomplete(self):
         # Given
-        file = findRelativePathFor("tests/integration/data/deploy_aws_incomplete.yml")
+        file = find_relative_path_for("tests/integration/data/deploy_aws_incomplete.yml")
 
         # When
         try:
@@ -56,7 +56,7 @@ class TestDeployUtils(TestCase):
 
     def testbuild_deployment_azure_returns_None_when_file_incomplete(self):
         # Given
-        file = findRelativePathFor("tests/integration/data/deploy_azure_incomplete.yml")
+        file = find_relative_path_for("tests/integration/data/deploy_azure_incomplete.yml")
 
         # When
         try:

--- a/tests/unit/utils/test_hammr_utils.py
+++ b/tests/unit/utils/test_hammr_utils.py
@@ -233,42 +233,42 @@ class TestFiles(unittest.TestCase):
         # Then
         mock_exec_command.assert_called_with("command to launch")
 
-    def test_validate_structure_template_return_None_when_stack_is_missing(self):
+    def test_validate_builder_file_with_no_template_id_return_None_when_stack_is_missing(self):
         # Given
         yaml_path = find_relative_path_for("tests/integration/data/publish_builder.yml")
 
         # When
-        data = hammr_utils.validate_structure_template(yaml_path)
+        data = hammr_utils.validate_builder_file_with_no_template_id(yaml_path)
 
         # Then
         self.assertEqual(data, None)
 
-    def test_validate_structure_template_return_None_when_builder_is_missing(self):
+    def test_validate_builder_file_with_no_template_id_return_None_when_builder_is_missing(self):
         # Given
         yaml_path = find_relative_path_for("tests/integration/data/test-parsing.yml")
 
         # When
-        data = hammr_utils.validate_structure_template(yaml_path)
+        data = hammr_utils.validate_builder_file_with_no_template_id(yaml_path)
 
         # Then
         self.assertEqual(data, None)
 
-    def test_validate_structure_template_return_data_when_stack_and_builder_are_not_missing(self):
+    def test_validate_validate_builder_file_with_no_template_id_return_data_when_stack_and_builder_are_not_missing(self):
         # Given
         json_path = find_relative_path_for("tests/integration/data/templatePXE.json")
 
         # When
-        data = hammr_utils.validate_structure_template(json_path)
+        data = hammr_utils.validate_builder_file_with_no_template_id(json_path)
 
         # Then
         self.assertNotEqual(data, None)
 
-    def test_validate_structure_template_return_None_when_stack_and_builder_are_missing(self):
+    def test_validate_builder_file_with_no_template_id_return_None_when_stack_and_builder_are_missing(self):
         # Given
         yaml_path = find_relative_path_for("tests/integration/data/deploy_aws.yml")
 
         # When
-        data = hammr_utils.validate_structure_template(yaml_path)
+        data = hammr_utils.validate_builder_file_with_no_template_id(yaml_path)
 
         # Then
         self.assertEqual(data, None)

--- a/tests/unit/utils/test_hammr_utils.py
+++ b/tests/unit/utils/test_hammr_utils.py
@@ -6,7 +6,7 @@ import yaml
 import paramiko
 
 from mock import patch
-from tests.unit.utils.file_utils import findRelativePathFor
+from tests.unit.utils.file_utils import find_relative_path_for
 
 from hammr.utils import constants
 from hammr.utils import hammr_utils
@@ -16,8 +16,8 @@ from uforge.application import Api
 class TestFiles(unittest.TestCase):
     def test_pythonObjectFromYamlParsingShouldBeTheSameAsJsonParsing(self):
         # Given
-        json_path = findRelativePathFor("tests/integration/data/test-parsing.json")
-        yaml_path = findRelativePathFor("tests/integration/data/test-parsing.yml")
+        json_path = find_relative_path_for("tests/integration/data/test-parsing.json")
+        yaml_path = find_relative_path_for("tests/integration/data/test-parsing.yml")
         # When
         json_data = json.load(open(json_path))
         yaml_data = yaml.load(open(yaml_path))

--- a/tests/unit/utils/test_publish_utils.py
+++ b/tests/unit/utils/test_publish_utils.py
@@ -19,7 +19,7 @@ from hammr.utils.hammr_utils import *
 from uforge.application import Api
 from uforge.objects.uforge import *
 from uforge.objects import uforge
-from tests.unit.utils.file_utils import findRelativePathFor
+from tests.unit.utils.file_utils import find_relative_path_for
 from mock import patch
 from hammr.commands.image import image
 
@@ -32,7 +32,7 @@ class TestPublishUtils(TestCase):
     def test_is_image_ready_to_publish_returns_true_when_memory_and_swap_size_are_defined(self):
         # given
         image = self.build_image_to_publish("complete", True, self.app_uri)
-        file = findRelativePathFor("tests/integration/data/publish_builder.yml")
+        file = find_relative_path_for("tests/integration/data/publish_builder.yml")
         builder = self.build_builder(file)
 
         # when
@@ -44,7 +44,7 @@ class TestPublishUtils(TestCase):
     def test_is_image_ready_to_publish_returns_false_when_status_is_cancelled(self):
         # given
         image = self.build_image_to_publish("cancelled", False, self.app_uri)
-        file = findRelativePathFor("tests/integration/data/publish_builder.yml")
+        file = find_relative_path_for("tests/integration/data/publish_builder.yml")
         builder = self.build_builder(file)
 
         # when


### PR DESCRIPTION
- Add a validator for the builder file if no id is provided when running "template build"
- When running "template build" with an id of a template, the behavior is the same as before
- Add unit tests to avoid regression regarding the two points above