### PR TITLE
Update migration with possibility to use identity file with scan agen…

### DIFF
--- a/hammr/commands/migration/migration.py
+++ b/hammr/commands/migration/migration.py
@@ -198,7 +198,7 @@ class Migration(Cmd, CoreGlobal):
         dir = "/tmp"
 
         binary_path = dir + "/" + constants.MIGRATION_BINARY_NAME
-        client = hammr_utils.upload_binary_to_client(hostname, port, username, password, file_src_path, binary_path)
+        client = hammr_utils.upload_binary_to_client(hostname, port, username, password, file_src_path, binary_path, None)
 
         command_launch = 'chmod +x ' + dir + '/' + constants.MIGRATION_BINARY_NAME + '; nohup ' + dir + '/' + constants.MIGRATION_BINARY_NAME + ' -u ' + uforge_login + ' -p ' + uforge_password + ' -U ' + uforge_url + ' -n \'' + \
                          migration_config["name"] + '\' ' + overlay + exclude + ' >/dev/null 2>&1 &'


### PR DESCRIPTION
…t (for now value of id_file is always None in migration to keep the same behavior as before)

This fixes a defect so no need to write something in the release note for this PR