### PR TITLE
Fix #476 Cannot publish to OpenStack when account has v3 as keystone version

### DIFF
--- a/hammr/commands/image/image.py
+++ b/hammr/commands/image/image.py
@@ -423,15 +423,19 @@ class Image(Cmd, CoreGlobal):
             appliance = appliance[0]
             publish_all_builders(self, template, appliance)
 
-    def retrieve_publish_image_with_target_format_builder(self, image, builder):
+    def retrieve_publish_image_with_target_format_builder(self, image, builder, cred_account):
         format_type = image.targetFormat.format.name
         publish_method = getattr(publish_builders, "publish_" + generics_utils.remove_special_chars(format_type), None)
         if publish_method:
-            publish_image = publish_method(builder)
+            if hasattr(cred_account, "keystoneVersion"):
+                publish_image = publish_method(builder, cred_account.keystoneVersion)
+            else:
+                publish_image = publish_method(builder)
             if publish_image is None:
                 raise ValueError("Could not find the builder")
         else:
             raise ValueError("Builder type unknown: " + format_type)
+        publish_image.credAccount = cred_account
         return publish_image
 
     def retrieve_appliances_from_name_and_version(self, query_string):

--- a/hammr/commands/migration/migration.py
+++ b/hammr/commands/migration/migration.py
@@ -92,11 +92,10 @@ class Migration(Cmd, CoreGlobal):
             image = migration_utils.retrieve_image(migration_config["target"]["builder"], target_format, self.api, self.login)
             if image is None:
                 return 2
-            publish_image = migration_utils.retrieve_publish_image(migration_config["target"]["builder"], target_format)
+            cred_account = migration_utils.retrieve_account(self.api, self.login, migration_config["target"]["builder"]["account"]["name"])
+            publish_image = migration_utils.retrieve_publish_image(migration_config["target"]["builder"], target_format, cred_account)
             if publish_image is None:
                 return 2
-            cred_account = migration_utils.retrieve_account(self.api, self.login, migration_config["target"]["builder"]["account"]["name"])
-            publish_image.credAccount = cred_account
 
             migration = self.create_migration(migration_config["name"], migration_config["os"], target_format.name, image, publish_image)
             self.api.Users(self.login).Migrations.Create(body=migration, element_name="ns1:migration")

--- a/hammr/utils/migration_utils.py
+++ b/hammr/utils/migration_utils.py
@@ -129,10 +129,15 @@ def set_install_profile_disk_size(install_profile, builder, image_format_name):
                 raise Exception("check yours parameters in file, no attribute [disksize] for [migration][target][builder][installation], mandatory to migrate to [" + builder["type"] +"]")
     return install_profile
 
-def retrieve_publish_image(builder, target_format):
+def retrieve_publish_image(builder, target_format, cred_account):
     create_publish_image_method = getattr(publish_builders, "publish_" + generics_utils.remove_special_chars(target_format.format.name), None)
     if create_publish_image_method:
-        return create_publish_image_method(builder)
+        if hasattr(cred_account, "keystoneVersion"):
+            publish_image = create_publish_image_method(builder, cred_account.keystoneVersion)
+        else:
+            publish_image = create_publish_image_method(builder)
+        publish_image.credAccount = cred_account
+        return publish_image
 
     raise Exception("TargetFormat type is unsupported: " + target_format.format.name)
 

--- a/hammr/utils/publish_builders.py
+++ b/hammr/utils/publish_builders.py
@@ -126,45 +126,49 @@ def publish_susecloud(builder):
     return pimage
 
 
-def publish_openstack(builder):
+def publish_openstack(builder, keystone_version):
     pimage = PublishImageOpenStack()
 
     # doing field verification
     if not "displayName" in builder:
         printer.out("displayName in openstack builder not found", printer.ERROR)
         return
-    if not "tenantName" in builder:
-        printer.out("TenantName in openstack builder not found", printer.ERROR)
-        return
+    if keystone_version == "v3":
+        if not "keystoneDomain" in builder:
+            printer.out("keystoneDomain in openstack builder not found when account keystone version is v3", printer.ERROR)
+            return
+        if not "keystoneProject" in builder:
+            printer.out("keystoneProject in openstack builder not found when account keystone version is v3", printer.ERROR)
+            return
+        pimage.keystoneDomain = builder["keystoneDomain"]
+        pimage.keystoneProject = builder["keystoneProject"]
+    else:
+        if not "tenantName" in builder:
+            printer.out("TenantName in openstack builder not found when account keystone version is v2.0", printer.ERROR)
+            return
+        pimage.tenantName = builder["tenantName"]
 
     pimage.displayName = builder["displayName"]
-    pimage.tenantName = builder["tenantName"]
-
     if "publicImage" in builder:
         pimage.credAccount.publicImage = True if (builder["publicImage"] == "true") else False
-    if "keystoneDomain" in builder:
-        pimage.keystoneDomain = builder["keystoneDomain"]
-        return
-    if "keystoneProject" in builder:
-        pimage.keystoneProject = builder["keystoneProject"]
-        return
+
     return pimage
 
 
-def publish_openstackqcow2(builder):
-    return publish_openstack(builder)
+def publish_openstackqcow2(builder, keystone_version):
+    return publish_openstack(builder, keystone_version)
 
 
-def publish_openstackvhd(builder):
-    return publish_openstack(builder)
+def publish_openstackvhd(builder, keystone_version):
+    return publish_openstack(builder, keystone_version)
 
 
-def publish_openstackvmdk(builder):
-    return publish_openstack(builder)
+def publish_openstackvmdk(builder, keystone_version):
+    return publish_openstack(builder, keystone_version)
 
 
-def publish_openstackvdi(builder):
-    return publish_openstack(builder)
+def publish_openstackvdi(builder, keystone_version):
+    return publish_openstack(builder, keystone_version)
 
 
 def publish_aws(builder):

--- a/hammr/utils/publish_utils.py
+++ b/hammr/utils/publish_utils.py
@@ -213,7 +213,8 @@ def publish_image_from_builder(image_object, builder, template, source, counter,
         if image is None:
             image = get_image_to_publish(image_object, builder, template, source, counter)
 
-        publish_image = image_object.retrieve_publish_image_with_target_format_builder(image, builder)
+        cred_account = get_account_to_publish(image_object, builder)
+        publish_image = image_object.retrieve_publish_image_with_target_format_builder(image, builder, cred_account)
         publish_image.imageUri = image.uri
         publish_image.parentUri = source.uri
         publish_image.credAccount = get_account_to_publish(image_object, builder)

--- a/tests/unit/commands/image/test_image.py
+++ b/tests/unit/commands/image/test_image.py
@@ -35,7 +35,7 @@ class TestImage(TestCase):
     @patch('texttable.Texttable.add_row')
     def test_do_list_check_size(self, mock_table_add_row, mock_api_pimg_getall, mock_api_getall):
         # given
-        i = self.create_image()
+        i = self.prepare_image()
         mock_api_getall.return_value = self.create_images(6000, "users/myuser/whatever/12/testing/18")
         new_pimages = uforge.publishImages()
         new_pimages.publishImages = pyxb.BIND()
@@ -51,7 +51,7 @@ class TestImage(TestCase):
     @patch('uforge.application.Api._Users._Images.Getall')
     def test_do_delete_return_2_for_wrong_image_uri(self, mock_api_getall, _raw_input):
         # Given
-        i = self.create_image()
+        i = self.prepare_image()
         mock_api_getall.return_value = self.create_images(6000, "users/myuser/whatever/12/testing/18")
 
         # When
@@ -64,7 +64,7 @@ class TestImage(TestCase):
     @patch('uforge.application.Api._Users._Images.Getall')
     def test_do_delete_return_2_for_wrong_arguments(self, mock_api_getall, _raw_input):
         # Given
-        i = self.create_image()
+        i = self.prepare_image()
         mock_api_getall.return_value = self.create_images(6000, "users/myuser/whatever/12/testing/18")
 
         # When
@@ -78,7 +78,7 @@ class TestImage(TestCase):
     @patch('uforge.application.Api._Users._Images.Getall')
     def test_do_delete_return_0_when_ok(self, mock_api_getall, _raw_input, mock_api_delete):
         # Given
-        i = self.create_image()
+        i = self.prepare_image()
         mock_api_getall.return_value = self.create_images(6000, "users/14/appliances/102/images/1")
 
         # When
@@ -91,7 +91,7 @@ class TestImage(TestCase):
     @patch('uforge.application.Api._Users._Images.Getall')
     def test_do_cancel_return_2_for_non_existing_image(self, mock_api_getall, _raw_input):
         # Given
-        i = self.create_image()
+        i = self.prepare_image()
         mock_api_getall.return_value = self.create_images(6000, "users/myuser/whatever/12/testing/18")
 
         # When
@@ -100,7 +100,74 @@ class TestImage(TestCase):
         # Then
         self.assertEqual(2, return_value)
 
-    def create_image(self):
+    @patch("hammr.utils.publish_builders.publish_vcenter")
+    def test_retrieve_publish_image_with_target_format_builder_return_the_publish_image_created(self,
+                                                                                                mock_publish_vcenter):
+        # given
+        i = self.prepare_image()
+
+        builder = {
+            "displayName": "vcenter-vm-name",
+            "esxHost": "esxhost_vcenter",
+            "datastore": "datastore_vcenter",
+            "network": "network_vcenter"
+        }
+
+        cred_account = uforge.CredAccountVSphere()
+
+        publish_image = uforge.PublishImageVSphere()
+        publish_image.displayName = builder["displayName"]
+        publish_image.esxHost = builder["esxHost"]
+        publish_image.datastore = builder["datastore"]
+        publish_image.network = builder["network"]
+
+        mock_publish_vcenter.return_value = publish_image
+
+        # when
+        publish_image_retrieved = i.retrieve_publish_image_with_target_format_builder(self.create_image("vcenter"), builder,
+                                                                                         cred_account)
+
+        # then
+        mock_publish_vcenter.assert_called_with(builder)
+        self.assertEqual(publish_image_retrieved.displayName, builder["displayName"])
+        self.assertEqual(publish_image_retrieved.esxHost, builder["esxHost"])
+        self.assertEqual(publish_image_retrieved.datastore, builder["datastore"])
+        self.assertEqual(publish_image_retrieved.network, builder["network"])
+
+    @patch("hammr.utils.publish_builders.publish_openstackqcow2")
+    def test_retrieve_publish_image_with_target_format_builder_call_publish_builder_method_with_keystone_version_when_openstack(
+            self,
+            mock_publish_openstackqcow2):
+        # given
+        i = self.prepare_image()
+
+        builder = {
+            "displayName": "openstackqcow2-vm-name",
+            "tenantName": "tenant_name",
+            "keystoneDomain": "keystone_domain"
+        }
+
+        cred_account = uforge.CredAccountOpenStack()
+        cred_account.keystoneVersion = "v3"
+
+        publish_image = uforge.PublishImageVSphere()
+        publish_image.displayName = builder["displayName"]
+        publish_image.tenantName = builder["tenantName"]
+        publish_image.keystoneDomain = builder["keystoneDomain"]
+
+        mock_publish_openstackqcow2.return_value = publish_image
+
+        # when
+        publish_image_retrieved = i.retrieve_publish_image_with_target_format_builder(self.create_image("openstackqcow2"), builder,
+                                                                                         cred_account)
+
+        # then
+        mock_publish_openstackqcow2.assert_called_with(builder, "v3")
+        self.assertEqual(publish_image_retrieved.displayName, builder["displayName"])
+        self.assertEqual(publish_image_retrieved.tenantName, builder["tenantName"])
+        self.assertEqual(publish_image_retrieved.keystoneDomain, builder["keystoneDomain"])
+
+    def prepare_image(self):
         i = image.Image()
         i.api = Api("url", username="username", password="password", headers=None,
                     disable_ssl_certificate_validation=False, timeout=constants.HTTP_TIMEOUT)
@@ -109,19 +176,28 @@ class TestImage(TestCase):
 
         return i
 
+    def create_image(self, target_format_name):
+        image_format = uforge.ImageFormat()
+        image_format.name = target_format_name
+
+        target_format = uforge.TargetFormat()
+        target_format.name = target_format_name
+        target_format.format = image_format
+
+        image = uforge.Image()
+        image.targetFormat = target_format
+        return image
 
     def create_images(self, size, uri):
         new_images = Images()
         new_images.images = pyxb.BIND()
 
-        new_image = Image()
+        new_image = self.create_image("vcenter")
         new_image.dbId = 1
         new_image.fileSize = size
         new_image.size = 0
         new_image.name = "test"
         new_image.status = "complete"
-        new_image.targetFormat = uforge.targetFormat()
-        new_image.targetFormat.name = "test"
         new_image.created = datetime.datetime.now()
         new_image.compress = True
         new_image.uri = uri

--- a/tests/unit/utils/test_publish_builders.py
+++ b/tests/unit/utils/test_publish_builders.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 from unittest import TestCase
+from mock import patch
 
 from hammr.utils.publish_builders import *
 
@@ -421,4 +422,138 @@ class TestPublishGoogle(TestCase):
         if storage_class is not None: builder["storageClass"] = storage_class
         if disk_name_prefix is not None: builder["diskNamePrefix"] = disk_name_prefix
 
+        return builder
+
+class TestPublishOpenStack(TestCase):
+    def test_publish_openstack_should_return_publish_image_when_valid_entries_for_v3(self):
+        # given
+        builder = self.build_builder_v3("testDisplayName", "testKeystoneDomain", "testKeystoneProject")
+
+        # when
+        pimage = publish_openstack(builder, "v3")
+
+        # then
+        self.assertEqual(pimage.displayName, builder["displayName"])
+        self.assertEqual(pimage.keystoneDomain, builder["keystoneDomain"])
+        self.assertEqual(pimage.keystoneProject, builder["keystoneProject"])
+
+    def test_publish_openstack_should_return_none_when_missing_keystoneDomain_for_v3(self):
+        # given
+        builder = self.build_builder_v3("testDisplayName", None, "testKeystoneProject")
+
+        # when
+        pimage = publish_openstack(builder, "v3")
+
+        # then
+        self.assertEqual(pimage, None)
+
+    def test_publish_openstack_should_return_none_when_missing_keystoneDomain_for_v3(self):
+        # given
+        builder = self.build_builder_v3("testDisplayName", "testKeystoneDomain", None)
+
+        # when
+        pimage = publish_openstack(builder, "v3")
+
+        # then
+        self.assertEqual(pimage, None)
+
+    def test_publish_openstack_should_return_none_when_missing_displayName_for_v3(self):
+        # given
+        builder = self.build_builder_v3(None, "testKeystoneDomain", "testKeystoneProject")
+
+        # when
+        pimage = publish_openstack(builder, "v3")
+
+        # then
+        self.assertEqual(pimage, None)
+
+    def test_publish_openstack_should_return_publish_image_when_valid_entries_for_v2(self):
+        # given
+        builder = self.build_builder_v2("testDisplayName", "testTenantName")
+
+        # when
+        pimage = publish_openstack(builder, "v2.0")
+
+        # then
+        self.assertEqual(pimage.displayName, builder["displayName"])
+        self.assertEqual(pimage.tenantName, builder["tenantName"])
+
+    def test_publish_openstack_should_return_none_when_missing_tenantName_for_v2(self):
+        # given
+        builder = self.build_builder_v2("testDisplayName", None)
+
+        # when
+        pimage = publish_openstack(builder, "v2.0")
+
+        # then
+        self.assertEqual(pimage, None)
+
+    def test_publish_openstack_should_return_none_when_missing_displayName_for_v2(self):
+        # given
+        builder = self.build_builder_v2(None, "testTenantName")
+
+        # when
+        pimage = publish_openstack(builder, "v2.0")
+
+        # then
+        self.assertEqual(pimage, None)
+
+    @patch("hammr.utils.publish_builders.publish_openstack")
+    def test_publish_openstackqcow2_should_call_publish_openstack_with_same_parameters(self, mock_publish_openstack):
+        # given
+        builder = self.build_builder("testDisplayNameqcow2")
+
+        # when
+        publish_openstackqcow2(builder, "vtestqcow2")
+
+        # then
+        mock_publish_openstack.assert_called_with(builder, "vtestqcow2")
+
+    @patch("hammr.utils.publish_builders.publish_openstack")
+    def test_publish_openstackvhd_should_call_publish_openstack_with_same_parameters(self, mock_publish_openstack):
+        # given
+        builder = self.build_builder("testDisplayNamevhd")
+
+        # when
+        publish_openstackvhd(builder, "vtestvhd")
+
+        # then
+        mock_publish_openstack.assert_called_with(builder, "vtestvhd")
+
+    @patch("hammr.utils.publish_builders.publish_openstack")
+    def test_publish_openstackvmdk_should_call_publish_openstack_with_same_parameters(self, mock_publish_openstack):
+        # given
+        builder = self.build_builder("testDisplayNamevmdk")
+
+        # when
+        publish_openstackvmdk(builder, "vtestvmdk")
+
+        # then
+        mock_publish_openstack.assert_called_with(builder, "vtestvmdk")
+
+    @patch("hammr.utils.publish_builders.publish_openstack")
+    def test_publish_openstackvdi_should_call_publish_openstack_with_same_parameters(self, mock_publish_openstack):
+        # given
+        builder = self.build_builder("testDisplayNamevdi")
+
+        # when
+        publish_openstackvdi(builder, "vtestvdi")
+
+        # then
+        mock_publish_openstack.assert_called_with(builder, "vtestvdi")
+
+    def build_builder(self, display_name):
+        builder = {}
+        if display_name is not None: builder["displayName"] = display_name
+        return builder
+
+    def build_builder_v2(self, display_name, tenant_name):
+        builder = self.build_builder(display_name)
+        if tenant_name is not None: builder["tenantName"] = tenant_name
+        return builder
+
+    def build_builder_v3(self, display_name, keystone_domain, keystone_project):
+        builder = self.build_builder(display_name)
+        if keystone_domain is not None: builder["keystoneDomain"] = keystone_domain
+        if keystone_project is not None: builder["keystoneProject"] = keystone_project
         return builder


### PR DESCRIPTION
- Add keystone version as parameter for openstack publish builder to verify fields keystoneDomain and keystoneProject if it's v3 or tenantName if it's v2.0
- Verify if account has attribute keystoneVersion to add in parameter of publish
- Add new unit tests arount openstack publish builder