### PR TITLE
Fix issue #488 Avoid several files with the same name in template archive

### DIFF
--- a/hammr/utils/bundle_utils.py
+++ b/hammr/utils/bundle_utils.py
@@ -74,20 +74,18 @@ def recursivelyAppendToArchive(bundle, files, parentDir, checkList, archive_file
     #must save the filepath before changing it after archive
     filePathBeforeTar = files["source"]
     if not "tag" in files or ("tag" in files and files["tag"] != "ospkg"):
-        if files["source"] not in checkList:
-            #add the source path to the check list
-            checkList.append(files["source"])
-            #if parentDir is a no empty path, add os.sep after. Else keep it as ""
-            if parentDir:
-                parentDir = parentDir + os.sep
-
-            #add to list of file to tar
-            file_tar_path=constants.FOLDER_BUNDLES + os.sep + generics_utils.remove_URI_forbidden_char(bundle["name"]) + os.sep + generics_utils.remove_URI_forbidden_char(bundle["version"]) + os.sep + parentDir + generics_utils.remove_URI_forbidden_char(ntpath.basename(files["source"]))
+        #if parentDir is a no empty path, add os.sep after. Else keep it as ""
+        if parentDir:
+            parentDir = parentDir + os.sep
+         #add to list of file to tar
+        file_tar_path=constants.FOLDER_BUNDLES + os.sep + generics_utils.remove_URI_forbidden_char(bundle["name"]) + os.sep + generics_utils.remove_URI_forbidden_char(bundle["version"]) + os.sep + parentDir + generics_utils.remove_URI_forbidden_char(ntpath.basename(files["name"]))
+        if file_tar_path not in checkList:
+            checkList.append(file_tar_path)
             archive_files.append([file_tar_path,files["source"]])
             #changing source path to archive related source path
             files["source"]=file_tar_path
         else:
-            raise ValueError("Cannot have identical files in the bundles section: " + filePathBeforeTar)
+            raise ValueError("Cannot have identical files in the bundles section: " + file_tar_path + " from " + filePathBeforeTar)
 
     if "files" in files:
         for subFiles in files["files"]:

--- a/tests/unit/utils/test_bundle_utils.py
+++ b/tests/unit/utils/test_bundle_utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 __author__ = 'UshareSoft'
 
 import unittest
@@ -7,13 +8,14 @@ from mock import patch
 
 from ussclicore.utils import generics_utils
 from hammr.utils import bundle_utils
+from tests.unit.utils.file_utils import find_relative_path_for
 
 class TestFiles(unittest.TestCase):
 
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_no_name(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleWithoutName.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleWithoutName.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -23,7 +25,7 @@ class TestFiles(unittest.TestCase):
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_no_version(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleWithoutVersion.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleWithoutVersion.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -33,7 +35,7 @@ class TestFiles(unittest.TestCase):
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_no_files(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleWithoutFiles.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleWithoutFiles.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -43,7 +45,7 @@ class TestFiles(unittest.TestCase):
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_files_no_name(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleFilesWithoutName.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleFilesWithoutName.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -53,7 +55,7 @@ class TestFiles(unittest.TestCase):
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_files_no_source(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleFilesWithoutSource.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleFilesWithoutSource.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -63,7 +65,7 @@ class TestFiles(unittest.TestCase):
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_tag_softwarefile_and_bootorder(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleFilesTagSoftwareFileKeyBootOrder.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleFilesTagSoftwareFileKeyBootOrder.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -73,7 +75,7 @@ class TestFiles(unittest.TestCase):
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_tag_bootscript_and_rights(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleFilesTagBootScriptKeyRights.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleFilesTagBootScriptKeyRights.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -83,7 +85,7 @@ class TestFiles(unittest.TestCase):
     @patch("ussclicore.utils.printer.out")
     def test_check_bundle_should_failed_when_tag_ospkg_in_directory(self, mock_method):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleFilesTagOSPkgInDirectory.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleFilesTagOSPkgInDirectory.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -92,7 +94,7 @@ class TestFiles(unittest.TestCase):
 
     def test_check_bundle_should_succeed_when_no_restrictionRule(self):
         # Given
-        jsonPath = "tests/integration/data/bundle/bundleWithoutRestrictionRule.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleWithoutRestrictionRule.json")
         # When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -101,7 +103,7 @@ class TestFiles(unittest.TestCase):
 
     def test_check_bundle_should_succeed_when_empty_restrictionRule(self):
         # Given
-        jsonPath = "tests/integration/data/bundle/bundleWithEmptyRestrictionRule.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleWithEmptyRestrictionRule.json")
         # When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle_utils.check_bundle(bundle)
@@ -110,12 +112,90 @@ class TestFiles(unittest.TestCase):
 
     def test_check_bundle_should_succeed(self):
         #Given
-        jsonPath = "tests/integration/data/bundle/bundleFull.json"
+        jsonPath = find_relative_path_for("tests/integration/data/bundle/bundleFull.json")
         #When
         bundle = generics_utils.check_json_syntax(jsonPath)
         bundle = bundle_utils.check_bundle(bundle)
         #Then
         self.assertIsNotNone(bundle)
+
+    def test_recursivelyAppendToArchive_should_failed_when_two_files_have_same_archive_path(self):
+        # Given
+        bundle = { 'name': 'MyBundle', 'version': '1.0' }
+        parent_dir = ""
+        check_list = []
+        archive_files = []
+        files = {
+            'name': 'myDirectory',
+            'source': 'tests/integration/data/directoryTest',
+            'tag': 'softwarefile',
+            'destination': '/usr/local/myBundle',
+            'files': [
+                {
+                    "name": "file.txt",
+                    "source": "tests/integration/data/directoryTest/file1of3.txt"
+                },
+                {
+                    "name": "file.txt",
+                    "source": "tests/integration/data/directoryTest/file2of3.txt"
+                }
+            ]
+        }
+        # When
+        with self.assertRaises(ValueError) as context_manager:
+            bundle_utils.recursivelyAppendToArchive(bundle, files, parent_dir, check_list, archive_files)
+
+        # Then
+        self.assertEqual(
+            context_manager.exception.message,
+            "Cannot have identical files in the bundles section: bundles/MyBundle/1.0/myDirectory/file.txt from tests/integration/data/directoryTest/file2of3.txt"
+        )
+
+    def test_recursivelyAppendToArchive_should_succeed_when_several_files_have_same_source(self):
+        # Given
+        bundle = { 'name': 'MyBundle', 'version': '1.0' }
+        parent_dir = ""
+        check_list = []
+        archive_files = []
+        files = {
+            'name': 'myDirectory',
+            'source': 'tests/integration/data/directoryTest',
+            'tag': 'softwarefile',
+            'destination': '/usr/local/myBundle',
+            'files': [
+                {
+                    'name': 'file1.txt',
+                    'source': 'tests/integration/data/directoryTest/file1of3.txt'
+                },
+                {
+                    'name': 'file2.txt',
+                    'source': 'tests/integration/data/directoryTest/file1of3.txt'
+                },
+                {
+                    'name': 'pkg1.rpm',
+                    'source': 'http://myServer.com/pkg1/download',
+                    'install': 'true'
+                },
+                {
+                    'name': 'pkg2.rpm',
+                    'source': 'http://myServer.com/pkg2/download',
+                    'install': 'true'
+                }
+            ]
+        }
+        # When
+        r_check_list, r_archive_files = bundle_utils.recursivelyAppendToArchive(bundle, files, parent_dir, check_list, archive_files)
+
+        # Then
+        self.assertEqual(archive_files, [
+            ['bundles/MyBundle/1.0/myDirectory', 'tests/integration/data/directoryTest'],
+            ['bundles/MyBundle/1.0/myDirectory/file1.txt', 'tests/integration/data/directoryTest/file1of3.txt'],
+            ['bundles/MyBundle/1.0/myDirectory/file2.txt', 'tests/integration/data/directoryTest/file1of3.txt'],
+            ['bundles/MyBundle/1.0/myDirectory/pkg1.rpm','http://myServer.com/pkg1/download'],
+            ['bundles/MyBundle/1.0/myDirectory/pkg2.rpm', 'http://myServer.com/pkg2/download']
+        ])
+        self.assertEqual(r_archive_files, archive_files)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/utils/test_bundle_utils.py
+++ b/tests/unit/utils/test_bundle_utils.py
@@ -127,17 +127,17 @@ class TestFiles(unittest.TestCase):
         archive_files = []
         files = {
             'name': 'myDirectory',
-            'source': 'tests/integration/data/directoryTest',
+            'source': 'tests/integration/data/aDirectory',
             'tag': 'softwarefile',
             'destination': '/usr/local/myBundle',
             'files': [
                 {
                     "name": "file.txt",
-                    "source": "tests/integration/data/directoryTest/file1of3.txt"
+                    "source": "tests/integration/data/aDirectory/file1of3.txt"
                 },
                 {
                     "name": "file.txt",
-                    "source": "tests/integration/data/directoryTest/file2of3.txt"
+                    "source": "tests/integration/data/aDirectory/file2of3.txt"
                 }
             ]
         }
@@ -148,7 +148,7 @@ class TestFiles(unittest.TestCase):
         # Then
         self.assertEqual(
             context_manager.exception.message,
-            "Cannot have identical files in the bundles section: bundles/MyBundle/1.0/myDirectory/file.txt from tests/integration/data/directoryTest/file2of3.txt"
+            "Cannot have identical files in the bundles section: bundles/MyBundle/1.0/myDirectory/file.txt from tests/integration/data/aDirectory/file2of3.txt"
         )
 
     def test_recursivelyAppendToArchive_should_succeed_when_several_files_have_same_source(self):
@@ -159,17 +159,17 @@ class TestFiles(unittest.TestCase):
         archive_files = []
         files = {
             'name': 'myDirectory',
-            'source': 'tests/integration/data/directoryTest',
+            'source': 'tests/integration/data/aDirectory',
             'tag': 'softwarefile',
             'destination': '/usr/local/myBundle',
             'files': [
                 {
                     'name': 'file1.txt',
-                    'source': 'tests/integration/data/directoryTest/file1of3.txt'
+                    'source': 'tests/integration/data/aDirectory/file1of3.txt'
                 },
                 {
                     'name': 'file2.txt',
-                    'source': 'tests/integration/data/directoryTest/file1of3.txt'
+                    'source': 'tests/integration/data/aDirectory/file1of3.txt'
                 },
                 {
                     'name': 'pkg1.rpm',
@@ -188,9 +188,9 @@ class TestFiles(unittest.TestCase):
 
         # Then
         self.assertEqual(archive_files, [
-            ['bundles/MyBundle/1.0/myDirectory', 'tests/integration/data/directoryTest'],
-            ['bundles/MyBundle/1.0/myDirectory/file1.txt', 'tests/integration/data/directoryTest/file1of3.txt'],
-            ['bundles/MyBundle/1.0/myDirectory/file2.txt', 'tests/integration/data/directoryTest/file1of3.txt'],
+            ['bundles/MyBundle/1.0/myDirectory', 'tests/integration/data/aDirectory'],
+            ['bundles/MyBundle/1.0/myDirectory/file1.txt', 'tests/integration/data/aDirectory/file1of3.txt'],
+            ['bundles/MyBundle/1.0/myDirectory/file2.txt', 'tests/integration/data/aDirectory/file1of3.txt'],
             ['bundles/MyBundle/1.0/myDirectory/pkg1.rpm','http://myServer.com/pkg1/download'],
             ['bundles/MyBundle/1.0/myDirectory/pkg2.rpm', 'http://myServer.com/pkg2/download']
         ])


### PR DESCRIPTION
- Use the required name attribute for the filename in the archive instead of the source filename
- Check to avoid two similar file path in the archive instead of checking that a same source file is not used two times