### PR TITLE
Fix duplicated files in folder filtering

### DIFF
--- a/hammr/commands/bundle/bundle.py
+++ b/hammr/commands/bundle/bundle.py
@@ -235,10 +235,10 @@ class Bundle(Cmd, CoreGlobal):
             isJsonFile= check_extension_is_json(file)
             archive_files=[]
             try:
-                checkList = []
+                duplicate_check_list = []
                 if "files" in bundle:
                     for files in bundle["files"]:
-                        checkList,archive_files = recursivelyAppendToArchive(bundle, files, "", checkList, archive_files)
+                        duplicate_check_list, archive_files = recursively_append_to_archive(bundle, files, "", duplicate_check_list, archive_files)
                 else:
                     printer.out("No files section found for bundle", printer.ERROR)
                     return 2

--- a/hammr/commands/template/template.py
+++ b/hammr/commands/template/template.py
@@ -271,12 +271,12 @@ class Template(Cmd, CoreGlobal):
                         printer.out("No source file found in config", printer.ERROR)
                         return 2
             try:
-                checkList = []
+                duplicate_check_list = []
                 if "bundles" in template["stack"]:
                     for bundle in template["stack"]["bundles"]:
                         if "files" in bundle:
                             for files in bundle["files"]:
-                                checkList,archive_files = recursivelyAppendToArchive(bundle, files, "", checkList, archive_files)
+                                duplicate_check_list, archive_files = recursively_append_to_archive(bundle, files, "", duplicate_check_list, archive_files)
                         else:
                             printer.out("No files section found for bundle", printer.ERROR)
                             return 2

--- a/hammr/utils/bundle_utils.py
+++ b/hammr/utils/bundle_utils.py
@@ -74,11 +74,13 @@ def recursivelyAppendToArchive(bundle, files, parentDir, checkList, archive_file
     #must save the filepath before changing it after archive
     filePathBeforeTar = files["source"]
     if not "tag" in files or ("tag" in files and files["tag"] != "ospkg"):
-        #if parentDir is a no empty path, add os.sep after. Else keep it as ""
-        if parentDir:
+        # if parentDir is a no empty path or already ending with os.sep, add os.sep at the end
+        if parentDir and not parentDir.endswith(os.sep):
             parentDir = parentDir + os.sep
-         #add to list of file to tar
-        file_tar_path=constants.FOLDER_BUNDLES + os.sep + generics_utils.remove_URI_forbidden_char(bundle["name"]) + os.sep + generics_utils.remove_URI_forbidden_char(bundle["version"]) + os.sep + parentDir + generics_utils.remove_URI_forbidden_char(ntpath.basename(files["name"]))
+        file_tar_path = constants.FOLDER_BUNDLES + os.sep + generics_utils.remove_URI_forbidden_char(bundle["name"]) \
+                      + os.sep + generics_utils.remove_URI_forbidden_char(bundle["version"]) \
+                      + os.sep + parentDir \
+                      + generics_utils.remove_URI_forbidden_char(ntpath.basename(files["name"]))
         if file_tar_path not in checkList:
             checkList.append(file_tar_path)
             archive_files.append([file_tar_path,files["source"]])
@@ -101,15 +103,19 @@ def processFilesFromFolder(bundle, files, filePath, parentDir, checkList, archiv
         subFilesDict = dict({"name" : ntpath.basename(subFiles), "source" : filePath + os.sep + ntpath.basename(subFiles), "files" : []})
         #must save the filepath before changing it after archive
         subFilePathBeforeTar = subFilesDict["source"]
-        if subFilesDict["source"] not in checkList:
-            #add the source path to the check list
-            checkList.append(subFilesDict["source"])
-            #if parentDir is a no empty path, add os.sep after. Else keep it as ""
-            if parentDir:
-                parentDir = parentDir + os.sep
 
-            #add to list of file to tar
-            file_tar_path=constants.FOLDER_BUNDLES + os.sep + generics_utils.remove_URI_forbidden_char(bundle["name"]) + os.sep + generics_utils.remove_URI_forbidden_char(bundle["version"]) + os.sep + parentDir + generics_utils.remove_URI_forbidden_char(ntpath.basename(subFilesDict["source"]))
+        # if parentDir is a no empty path or already ending with os.sep, add os.sep at the end
+        if parentDir and not parentDir.endswith(os.sep):
+            parentDir = parentDir + os.sep
+
+        # add to list of file to tar
+        file_tar_path = constants.FOLDER_BUNDLES + os.sep + generics_utils.remove_URI_forbidden_char(
+            bundle["name"]) + os.sep + generics_utils.remove_URI_forbidden_char(
+            bundle["version"]) + os.sep + parentDir + generics_utils.remove_URI_forbidden_char(
+            ntpath.basename(subFilesDict["source"]))
+
+        if file_tar_path not in checkList:
+            checkList.append(file_tar_path)
             archive_files.append([file_tar_path,subFilesDict["source"]])
             #changing source path to archive related source path and add it to files section of parent folder
             subFilesDict["source"] = file_tar_path

--- a/tests/unit/utils/test_bundle_utils.py
+++ b/tests/unit/utils/test_bundle_utils.py
@@ -119,11 +119,11 @@ class TestFiles(unittest.TestCase):
         #Then
         self.assertIsNotNone(bundle)
 
-    def test_recursivelyAppendToArchive_should_failed_when_two_files_have_same_archive_path(self):
+    def test_recursively_append_to_archive_should_failed_when_two_files_have_same_archive_path(self):
         # Given
         bundle = { 'name': 'MyBundle', 'version': '1.0' }
         parent_dir = ""
-        check_list = []
+        duplicate_check_list = []
         archive_files = []
         files = {
             'name': 'myDirectory',
@@ -143,7 +143,7 @@ class TestFiles(unittest.TestCase):
         }
         # When
         with self.assertRaises(ValueError) as context_manager:
-            bundle_utils.recursivelyAppendToArchive(bundle, files, parent_dir, check_list, archive_files)
+            bundle_utils.recursively_append_to_archive(bundle, files, parent_dir, duplicate_check_list, archive_files)
 
         # Then
         self.assertEqual(
@@ -151,11 +151,11 @@ class TestFiles(unittest.TestCase):
             "Cannot have identical files in the bundles section: bundles/MyBundle/1.0/myDirectory/file.txt from tests/integration/data/aDirectory/file2of3.txt"
         )
 
-    def test_recursivelyAppendToArchive_should_succeed_when_several_files_have_same_source(self):
+    def test_recursively_append_to_archive_should_succeed_when_several_files_have_same_source(self):
         # Given
         bundle = { 'name': 'MyBundle', 'version': '1.0' }
         parent_dir = ""
-        check_list = []
+        duplicate_check_list = []
         archive_files = []
         files = {
             'name': 'myDirectory',
@@ -184,7 +184,7 @@ class TestFiles(unittest.TestCase):
             ]
         }
         # When
-        r_check_list, r_archive_files = bundle_utils.recursivelyAppendToArchive(bundle, files, parent_dir, check_list, archive_files)
+        r_duplicate_check_list, r_archive_files = bundle_utils.recursively_append_to_archive(bundle, files, parent_dir, duplicate_check_list, archive_files)
 
         # Then
         self.assertEqual(archive_files, [
@@ -196,6 +196,36 @@ class TestFiles(unittest.TestCase):
         ])
         self.assertEqual(r_archive_files, archive_files)
 
+    def test_recursively_append_to_archive_should_succeed_when_directory_contains_file_already_described(self):
+        # Given
+        bundle = { 'name': 'MyBundle', 'version': '1.0' }
+        parent_dir = ""
+        duplicate_check_list = []
+        archive_files = []
+        files = {
+            'name': 'directoryTest',
+            'source': 'tests/integration/data/directoryTest',
+            'tag': 'softwarefile',
+            'destination': '/usr/local/myBundle',
+            'files': [
+                {
+                    'name': 'file1of3.txt',
+                    'source': 'tests/integration/data/directoryTest/file1of3.txt',
+                    'rights': '625',
+                }
+            ]
+        }
+        # When
+        r_duplicate_check_list, r_archive_files = bundle_utils.recursively_append_to_archive(bundle, files, parent_dir, duplicate_check_list, archive_files)
+
+        # Then
+        self.assertEqual(archive_files, [
+            ['bundles/MyBundle/1.0/directoryTest', 'tests/integration/data/directoryTest'],
+            ['bundles/MyBundle/1.0/directoryTest/file1of3.txt', 'tests/integration/data/directoryTest/file1of3.txt'],
+            ['bundles/MyBundle/1.0/directoryTest/file2of3.txt', 'tests/integration/data/directoryTest/file2of3.txt'],
+            ['bundles/MyBundle/1.0/directoryTest/file3of3.txt', 'tests/integration/data/directoryTest/file3of3.txt']
+        ])
+        self.assertEqual(r_archive_files, archive_files)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Fix the regression introduced by b7c4d729e3f69c349c749e593b73c7270e6f17c1
- Filter duplicates on target path instead of target source
- Avoid adding "/" to the path when there is already one