### PR TITLE
Display the Docker pull command when downloading Docker based images

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -3,6 +3,13 @@
 Changelog
 =========
 
+hammr 3.8.13 (2019-06-10)
+-------------------------
+
+Evolutions:
+
+* ``hammr image download`` command now displays the ``docker pull`` command for Docker based images
+
 hammr 3.8.12 (2018-04-29)
 -------------------------
 

--- a/documentation/en/source/pages/command-line/image.rst
+++ b/documentation/en/source/pages/command-line/image.rst
@@ -44,7 +44,7 @@ Deploy an instance of a published image on the targeted cloud. The options are:
 Downloads a machine image to the local filesystem. The options are:
 
 	* ``--id`` (mandatory): the ID of the machine image to download
-	* ``--file`` (mandatory): the pathname where to store the machine image
+	* ``--file`` (optional): the pathname where to store the machine image
 
 ``info`` sub-command
 ~~~~~~~~~~~~~~~~~~~~

--- a/documentation/en/source/pages/machine-images/machine-image-download.rst
+++ b/documentation/en/source/pages/machine-images/machine-image-download.rst
@@ -5,15 +5,24 @@
 Downloading a Machine Image
 ===========================
 
-You can only download images that have been compressed. You will need the image ``Id`` number in order to download it as follows. You must also set the location where the image should be saved.  To download a machine image, use the command ``image download``.
+Only compressed images and Docker based images can be downloaded.
+
+In case of a compressed image, you will need the image ``Id`` number in order to download it as follows. You must also set the location where the image should be saved.  To download a machine image, use the command ``image download``.
 
 .. code-block:: shell
 
-	$ hammr image download -c ~/.hammr/credentials-UFOL.yml --id 17517 --file /tmp/test.tar,gz
-	INFO: no username nor password provided on command line, trying credentials file
-	INFO: Using credentials file: /home/joris/.hammr/credentials-UFOL.yml
-	INFO: Using url https://factory.usharesoft.com/api
-	Searching image with id [17517] ...
-	Status: 100% |>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>| Time: 0:01:11
-	OK: Image downloaded
+    $ hammr image download -c ~/.hammr/credentials-UFOL.yml --id 17517 --file /tmp/test.tar,gz
+    INFO: no username nor password provided on command line, trying credentials file
+    INFO: Using credentials file: /home/joris/.hammr/credentials-UFOL.yml
+    INFO: Using url https://uforge.usharesoft.com/api
+    Searching image with id [17517] ...
+    Status: 100% |>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>| Time: 0:01:11
+    OK: Image downloaded
 
+In case of a Docker based image, you will need the image ``Id`` number in order to retrieve the ``docker pull`` command through the ``image download`` command.
+
+.. code-block:: shell
+
+    $ hammr image download --id 130590
+    OK: In order to download the image, please run:
+    docker pull uforge.usharesoft.com/software/718/130590/32ee61a82362705babd8daf07cd509a4ca93f0e

--- a/tests/unit/commands/image/info_test_utils.py
+++ b/tests/unit/commands/image/info_test_utils.py
@@ -49,7 +49,7 @@ def create_image_format_docker():
     image = create_image()
     image.targetFormat.name = "docker"
     image.targetFormat.format.name = "docker"
-    image.registeringName = "registering name"
+    image.registeringName = "registry/1/qwerty"
     image.entrypoint = "['/usr/sbin/httpd','-DFOREGROUND']"
 
     return image

--- a/tests/unit/commands/image/test_image.py
+++ b/tests/unit/commands/image/test_image.py
@@ -305,20 +305,6 @@ class TestImage(TestCase):
         # Then
         self.assertEqual(2, return_value)
 
-    @patch("ussclicore.utils.printer.out")
-    @patch("hammr.commands.image.Image.get_all_images")
-    def test_do_download_should_display_command_when_docker_format(self, get_all_images, printer):
-        # given
-        i = self.prepare_image()
-        image = info_utils.create_image_format_docker()
-        get_all_images.return_value = [image]
-
-        # when
-        i.do_download("--id " + str(image.dbId))
-
-        # then
-        printer.assert_called_with("docker pull " + image.registeringName)
-
     @patch("hammr.utils.publish_builders.publish_vcenter")
     def test_build_publish_image_return_the_publish_image_created(self, mock_publish_vcenter):
         # given
@@ -350,6 +336,20 @@ class TestImage(TestCase):
         self.assertEqual(publish_image_retrieved.esxHost, builder["esxHost"])
         self.assertEqual(publish_image_retrieved.datastore, builder["datastore"])
         self.assertEqual(publish_image_retrieved.network, builder["network"])
+
+    @patch("ussclicore.utils.printer.out")
+    @patch("hammr.commands.image.image.Image.get_all_images")
+    def test_do_download_should_display_command_when_docker_format(self, get_all_images, printer):
+        # given
+        i = self.prepare_image()
+        image = info_utils.create_image_format_docker()
+        get_all_images.return_value = [image]
+
+        # when
+        i.do_download("--id " + str(image.dbId))
+
+        # then
+        printer.assert_called_with("docker pull " + image.registeringName)
 
     def prepare_image(self):
         i = image.Image()

--- a/tests/unit/commands/image/test_image.py
+++ b/tests/unit/commands/image/test_image.py
@@ -305,6 +305,20 @@ class TestImage(TestCase):
         # Then
         self.assertEqual(2, return_value)
 
+    @patch("ussclicore.utils.printer.out")
+    @patch("hammr.commands.image.Image.get_all_images")
+    def test_do_download_should_display_command_when_docker_format(self, get_all_images, printer):
+        # given
+        i = self.prepare_image()
+        image = info_utils.create_image_format_docker()
+        get_all_images.return_value = [image]
+
+        # when
+        i.do_download("--id " + str(image.dbId))
+
+        # then
+        printer.assert_called_with("docker pull " + image.registeringName)
+
     @patch("hammr.utils.publish_builders.publish_vcenter")
     def test_build_publish_image_return_the_publish_image_created(self, mock_publish_vcenter):
         # given


### PR DESCRIPTION
 - build the pull command when docker formats with registering name
 - move file parameter as optional
 - fix error return code when download fails